### PR TITLE
Added memo-transfer to token-2022 extensions

### DIFF
--- a/programs/token-2022/src/extensions/memo_transfer/instructions/disable_required_transfer_memos.rs
+++ b/programs/token-2022/src/extensions/memo_transfer/instructions/disable_required_transfer_memos.rs
@@ -1,0 +1,53 @@
+use crate::extensions::memo_transfer::state::{
+    encode_instruction_data, RequiredMemoTransfersInstruction,
+};
+use core::slice::from_raw_parts;
+use pinocchio::{
+    account_info::AccountInfo,
+    cpi::invoke_signed,
+    instruction::{AccountMeta, Instruction, Signer},
+    pubkey::Pubkey,
+    ProgramResult,
+};
+
+/// CPI helper to disable required memos on a token **account**.
+///
+/// Accounts (ordered):
+///   0. `[writable]` token account to update
+///   1. `[signer]`  account owner (single-owner flow)
+///
+/// Multisig flow is not covered in this minimal wrapper. Extend by adding
+/// additional signer `AccountMeta`s and `AccountInfo`s when needed.
+pub struct DisableRequiredTransferMemos<'a, 'b> {
+    /// Token Account to update.
+    pub account: &'a AccountInfo,
+    /// The account's owner (must sign).
+    pub owner: &'a AccountInfo,
+    /// Token program ID (Token-2022).
+    pub token_program: &'b Pubkey,
+}
+
+impl DisableRequiredTransferMemos<'_, '_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        let account_metas = [
+            AccountMeta::writable(self.account.key()),
+            AccountMeta::readonly_signer(self.owner.key()),
+        ];
+
+        let data = encode_instruction_data(RequiredMemoTransfersInstruction::Disable);
+
+        let instruction = Instruction {
+            accounts: &account_metas,
+            data: unsafe { from_raw_parts(data.as_ptr() as _, data.len()) },
+            program_id: self.token_program,
+        };
+
+        invoke_signed(&instruction, &[self.account, self.owner], signers)
+    }
+}

--- a/programs/token-2022/src/extensions/memo_transfer/instructions/enable_required_transfer_memos.rs
+++ b/programs/token-2022/src/extensions/memo_transfer/instructions/enable_required_transfer_memos.rs
@@ -1,0 +1,53 @@
+use crate::extensions::memo_transfer::state::{
+    encode_instruction_data, RequiredMemoTransfersInstruction,
+};
+use core::slice::from_raw_parts;
+use pinocchio::{
+    account_info::AccountInfo,
+    cpi::invoke_signed,
+    instruction::{AccountMeta, Instruction, Signer},
+    pubkey::Pubkey,
+    ProgramResult,
+};
+
+/// CPI helper to enable required memos on a token **account**.
+///
+/// Accounts (ordered):
+///   0. `[writable]` token account to update
+///   1. `[signer]`  account owner (single-owner flow)
+///
+/// Multisig flow is not covered in this minimal wrapper. Extend by adding
+/// additional signer `AccountMeta`s and `AccountInfo`s when needed.
+pub struct EnableRequiredTransferMemos<'a, 'b> {
+    /// Token Account to update.
+    pub account: &'a AccountInfo,
+    /// The account's owner (must sign).
+    pub owner: &'a AccountInfo,
+    /// Token program ID (Token-2022).
+    pub token_program: &'b Pubkey,
+}
+
+impl EnableRequiredTransferMemos<'_, '_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        let account_metas = [
+            AccountMeta::writable(self.account.key()),
+            AccountMeta::readonly_signer(self.owner.key()),
+        ];
+
+        let data = encode_instruction_data(RequiredMemoTransfersInstruction::Enable);
+
+        let instruction = Instruction {
+            accounts: &account_metas,
+            data: unsafe { from_raw_parts(data.as_ptr() as _, data.len()) },
+            program_id: self.token_program,
+        };
+
+        invoke_signed(&instruction, &[self.account, self.owner], signers)
+    }
+}

--- a/programs/token-2022/src/extensions/memo_transfer/instructions/mod.rs
+++ b/programs/token-2022/src/extensions/memo_transfer/instructions/mod.rs
@@ -1,0 +1,2 @@
+pub mod enable_required_transfer_memos;
+pub mod disable_required_transfer_memos;

--- a/programs/token-2022/src/extensions/memo_transfer/mod.rs
+++ b/programs/token-2022/src/extensions/memo_transfer/mod.rs
@@ -1,0 +1,2 @@
+pub mod state;
+pub mod instructions;

--- a/programs/token-2022/src/extensions/memo_transfer/state.rs
+++ b/programs/token-2022/src/extensions/memo_transfer/state.rs
@@ -1,0 +1,37 @@
+use crate::{write_bytes, UNINIT_BYTE};
+use core::mem::MaybeUninit;
+
+/// Sub-instruction for the Token-2022 Memo Transfer extension.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RequiredMemoTransfersInstruction {
+    /// Require memos for transfers into this Account.
+    Enable = 0,
+    /// Stop requiring memos for transfers into this Account.
+    Disable = 1,
+}
+
+/// Discriminator for `TokenInstruction::MemoTransferExtension`.
+/// Matches the Token-2022 core program instruction discriminator.
+/// See: https://solana-labs.github.io/solana-program-library/token/js/enums/TokenInstruction.html
+const MEMO_TRANSFER_EXTENSION: u8 = 30;
+
+/// Packs instruction data for a `RequiredMemoTransfersInstruction`.
+///
+/// Layout (little-endian bytes):
+/// - [0]: extension discriminator (1 byte, u8)
+/// - [1]: instruction kind        (1 byte, u8)
+#[inline(always)]
+pub fn encode_instruction_data(
+    instruction_type: RequiredMemoTransfersInstruction,
+) -> [MaybeUninit<u8>; 2] {
+    let mut data = [UNINIT_BYTE; 2];
+
+    // Set extension discriminator at offset [0]
+    write_bytes(&mut data, &[MEMO_TRANSFER_EXTENSION]);
+
+    // Set sub-instruction at offset [1]
+    write_bytes(&mut data[1..2], &[instruction_type as u8]);
+
+    data
+}

--- a/programs/token-2022/src/extensions/mod.rs
+++ b/programs/token-2022/src/extensions/mod.rs
@@ -1,0 +1,1 @@
+pub mod memo_transfer;

--- a/programs/token-2022/src/lib.rs
+++ b/programs/token-2022/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod instructions;
 pub mod state;
+pub mod extensions;
 
 pinocchio_pubkey::declare_id!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
 


### PR DESCRIPTION
Description:
This PR introduces the Memo Transfer extension for Token-2022 in Pinocchio.

- Implemented state.rs with RequiredMemoTransfersInstruction enum and encoder.
- Added CPI wrappers: EnableRequiredTransferMemos and DisableRequiredTransferMemos
   Structured under extensions/memo_transfer/ with instructions module.
- Updated extensions/mod.rs to export the new module.