### PR TITLE
Feat/pausable token extension

### DIFF
--- a/programs/token-2022/src/extensions/mod.rs
+++ b/programs/token-2022/src/extensions/mod.rs
@@ -1,0 +1,1 @@
+pub mod pausable;

--- a/programs/token-2022/src/extensions/pausable/initialize.rs
+++ b/programs/token-2022/src/extensions/pausable/initialize.rs
@@ -1,0 +1,58 @@
+use core::slice::from_raw_parts;
+
+use pinocchio::{
+    account_info::AccountInfo,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    ProgramResult,
+};
+
+use crate::{
+    extensions::pausable::{INITIALIZE, PAUSABLE_EXTENSION},
+    write_bytes, UNINIT_BYTE,
+};
+
+/// Initialize the pausable extension for the given mint account
+///
+/// Fails if the account has already been initialized, so must be called
+/// before `InitializeMint`.
+///
+/// ### Accounts:
+///   0. `[WRITE]` The mint.
+pub struct Initialize<'a, 'b> {
+    /// Mint Account.
+    pub mint: &'a AccountInfo,
+    /// Authority
+    pub authority: &'a Pubkey,
+    /// Token Program
+    pub token_program: &'b Pubkey,
+}
+
+impl Initialize<'_, '_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        let account_metas: [AccountMeta; 1] = [AccountMeta::writable(self.mint.key())];
+
+        // Instruction data layout:
+        // - [0]: token_instruction_type: (1 byte, u8)
+        // - [1]: instruction_type: (1 byte, u8)
+        // - [2..34] authority (32 bytes, Pubkey)
+        let mut instruction_data = [UNINIT_BYTE; 34];
+
+        // Set discriminator as u8 at offset [0] for PausableExtension token instruction
+        write_bytes(&mut instruction_data, &[PAUSABLE_EXTENSION]);
+        // Set discriminator as u8 at offset [1] for Initialize instruction
+        write_bytes(&mut instruction_data[1..2], &[INITIALIZE]);
+        // Set authority as Pubkey at offset [2..34]
+        write_bytes(&mut instruction_data, self.authority);
+
+        let instruction = Instruction {
+            program_id: self.token_program,
+            accounts: &account_metas,
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, instruction_data.len()) },
+        };
+
+        invoke(&instruction, &[self.mint])
+    }
+}

--- a/programs/token-2022/src/extensions/pausable/initialize.rs
+++ b/programs/token-2022/src/extensions/pausable/initialize.rs
@@ -13,13 +13,13 @@ use crate::{
     write_bytes, UNINIT_BYTE,
 };
 
-/// Initialize the pausable extension for the given mint account
+/// Initialize the pausable extension for the given mint account.
 ///
 /// Fails if the account has already been initialized, so must be called
 /// before `InitializeMint`.
 ///
 /// ### Accounts:
-///   0. `[WRITE]` The mint.
+///   0. `[WRITE]` The mint account to initialize.
 pub struct Initialize<'a, 'b> {
     /// Mint Account.
     pub mint: &'a AccountInfo,

--- a/programs/token-2022/src/extensions/pausable/initialize.rs
+++ b/programs/token-2022/src/extensions/pausable/initialize.rs
@@ -20,8 +20,11 @@ use crate::{
 ///
 /// ### Accounts:
 ///   0. `[WRITE]` The mint account to initialize.
+///
+///  ### Data:
+///   0. `authority` Pubkey of the mint's pause authority.
 pub struct Initialize<'a, 'b> {
-    /// Mint Account.
+    /// Mint Account
     pub mint: &'a AccountInfo,
     /// Authority
     pub authority: &'a Pubkey,
@@ -45,7 +48,7 @@ impl Initialize<'_, '_> {
         // Set discriminator as u8 at offset [1] for Initialize instruction
         write_bytes(&mut instruction_data[1..2], &[INITIALIZE]);
         // Set authority as Pubkey at offset [2..34]
-        write_bytes(&mut instruction_data, self.authority);
+        write_bytes(&mut instruction_data[2..34], self.authority);
 
         let instruction = Instruction {
             program_id: self.token_program,

--- a/programs/token-2022/src/extensions/pausable/mod.rs
+++ b/programs/token-2022/src/extensions/pausable/mod.rs
@@ -1,0 +1,3 @@
+pub mod initialize;
+pub mod pause;
+pub mod resume;

--- a/programs/token-2022/src/extensions/pausable/mod.rs
+++ b/programs/token-2022/src/extensions/pausable/mod.rs
@@ -1,3 +1,15 @@
 pub mod initialize;
 pub mod pause;
 pub mod resume;
+
+/// Discriminator for `TokenInstruction::PausableExtension`
+const PAUSABLE_EXTENSION: u8 = 44;
+
+/// Discriminator for `PausableInstruction::Initialze`
+const INITIALIZE: u8 = 0;
+
+/// Discriminator for `PausableInstruction::Pause`
+const PAUSE: u8 = 1;
+
+/// Discriminator for `PausableInstruction::Resume`
+const RESUME: u8 = 2;

--- a/programs/token-2022/src/extensions/pausable/pause.rs
+++ b/programs/token-2022/src/extensions/pausable/pause.rs
@@ -42,7 +42,7 @@ impl Pause<'_, '_> {
 
         // Set discriminator as u8 at offset [0] for PausableExtension token instruction
         write_bytes(&mut instruction_data, &[PAUSABLE_EXTENSION]);
-        // Set discriminator as u8 at offset [1] for Initialize instruction
+        // Set discriminator as u8 at offset [1] for Pause instruction
         write_bytes(&mut instruction_data[1..2], &[PAUSE]);
 
         let instruction = Instruction {
@@ -51,6 +51,6 @@ impl Pause<'_, '_> {
             data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, instruction_data.len()) },
         };
 
-        invoke(&instruction, &[self.mint])
+        invoke(&instruction, &[self.mint, self.authority])
     }
 }

--- a/programs/token-2022/src/extensions/pausable/pause.rs
+++ b/programs/token-2022/src/extensions/pausable/pause.rs
@@ -1,0 +1,56 @@
+use core::slice::from_raw_parts;
+
+use pinocchio::{
+    account_info::AccountInfo,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    ProgramResult,
+};
+
+use crate::{
+    extensions::pausable::{PAUSABLE_EXTENSION, PAUSE},
+    write_bytes, UNINIT_BYTE,
+};
+
+/// Pause minting, burning, and transferring for the mint.
+///
+/// ### Accounts:
+///   0. `[WRITE]` The mint to update.
+///   1. `[SIGNER]` The mint's pause authority.
+pub struct Pause<'a, 'b> {
+    /// Mint account
+    pub mint: &'a AccountInfo,
+    /// Authority
+    pub authority: &'a AccountInfo,
+    /// Token program
+    pub token_program: &'b Pubkey,
+}
+
+impl Pause<'_, '_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        let account_metas: [AccountMeta; 2] = [
+            AccountMeta::writable(self.mint.key()),
+            AccountMeta::readonly_signer(self.authority.key()),
+        ];
+
+        // Instruction data layout:
+        // - [0]: token_instruction_type: (1 byte, u8)
+        // - [1]: instruction_type: (1 byte, u8)
+        let mut instruction_data = [UNINIT_BYTE; 2];
+
+        // Set discriminator as u8 at offset [0] for PausableExtension token instruction
+        write_bytes(&mut instruction_data, &[PAUSABLE_EXTENSION]);
+        // Set discriminator as u8 at offset [1] for Initialize instruction
+        write_bytes(&mut instruction_data[1..2], &[PAUSE]);
+
+        let instruction = Instruction {
+            program_id: self.token_program,
+            accounts: &account_metas,
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, instruction_data.len()) },
+        };
+
+        invoke(&instruction, &[self.mint])
+    }
+}

--- a/programs/token-2022/src/extensions/pausable/resume.rs
+++ b/programs/token-2022/src/extensions/pausable/resume.rs
@@ -1,0 +1,56 @@
+use core::slice::from_raw_parts;
+
+use pinocchio::{
+    account_info::AccountInfo,
+    cpi::invoke,
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    ProgramResult,
+};
+
+use crate::{
+    extensions::pausable::{PAUSABLE_EXTENSION, RESUME},
+    write_bytes, UNINIT_BYTE,
+};
+
+/// Resume minting, burning, and transferring for the mint.
+///
+/// ### Accounts:
+///   0. `[WRITE]` The mint to update.
+///   1. `[SIGNER]` The mint's pause authority.
+pub struct Resume<'a, 'b> {
+    /// Mint account
+    pub mint: &'a AccountInfo,
+    /// Authority
+    pub authority: &'a AccountInfo,
+    /// Token program
+    pub token_program: &'b Pubkey,
+}
+
+impl Resume<'_, '_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        let account_metas = [
+            AccountMeta::writable(self.mint.key()),
+            AccountMeta::readonly_signer(self.authority.key()),
+        ];
+
+        // Instruction data layout:
+        // - [0]: token_instruction_type: (1 byte, u8)
+        // - [1]: instruction_type: (1 byte, u8)
+        let mut instruction_data = [UNINIT_BYTE; 2];
+
+        // Set discriminator as u8 at offset [0] for PausableExtension token instruction
+        write_bytes(&mut instruction_data, &[PAUSABLE_EXTENSION]);
+        // Set discriminator as u8 at offset [1] for Resume instruction
+        write_bytes(&mut instruction_data[1..2], &[RESUME]);
+
+        let instruction = Instruction {
+            program_id: self.token_program,
+            accounts: &account_metas,
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, instruction_data.len()) },
+        };
+
+        invoke(&instruction, &[self.mint, self.authority])
+    }
+}

--- a/programs/token-2022/src/lib.rs
+++ b/programs/token-2022/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+pub mod extensions;
 pub mod instructions;
 pub mod state;
 


### PR DESCRIPTION
### Description

This PR introduces the Pausable extension for Token-2022 in Pinnochio.

- Implement the three pausable instruction: Initialize, Pause and Resume
- Define discriminators in mod.rs

