### PR TITLE
Added Metadata Pointer to token-2022 extensions

### DIFF
--- a/programs/token-2022/src/extensions/metadata_pointer/instructions/initialize.rs
+++ b/programs/token-2022/src/extensions/metadata_pointer/instructions/initialize.rs
@@ -1,0 +1,52 @@
+use core::slice::from_raw_parts;
+
+use pinocchio::{
+    account_info::AccountInfo,
+    instruction::{AccountMeta, Instruction, Signer},
+    program::invoke_signed,
+    pubkey::Pubkey,
+    ProgramResult,
+};
+
+use crate::UNINIT_BYTE;
+use crate::extensions::metadata_pointer::state::encode_initialize_instruction_data;
+
+pub struct MetadataPointerInitialize<'a, 'b> {
+    /// The mint to initialize with the metadata pointer extension.
+    pub mint: &'a AccountInfo,
+    /// Optional authority that can later update the metadata address.
+    pub authority: Option<&'a Pubkey>,
+    /// Optional initial metadata address.
+    pub metadata_address: Option<&'a Pubkey>,
+    /// Token program (Token-2022).
+    pub token_program: &'b Pubkey,
+}
+
+impl MetadataPointerInitialize<'_, '_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        // Account meta layout
+        let account_metas = [AccountMeta::writable(self.mint.key())];
+
+        // Encode: [39, 0, authority(32), metadata_address(32)]
+        let mut instruction_data = [UNINIT_BYTE; 66];
+        let written = encode_initialize_instruction_data(
+            &mut instruction_data,
+            self.authority,
+            self.metadata_address,
+        );
+
+        let ix = Instruction {
+            program_id: self.token_program,
+            accounts: &account_metas,
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, written) },
+        };
+
+        invoke_signed(&ix, &[self.mint], signers)
+    }
+}

--- a/programs/token-2022/src/extensions/metadata_pointer/instructions/mod.rs
+++ b/programs/token-2022/src/extensions/metadata_pointer/instructions/mod.rs
@@ -1,0 +1,2 @@
+pub mod initialize;
+pub mod update;

--- a/programs/token-2022/src/extensions/metadata_pointer/instructions/update.rs
+++ b/programs/token-2022/src/extensions/metadata_pointer/instructions/update.rs
@@ -1,0 +1,54 @@
+// programs/token-2022/src/extensions/metadata_pointer/instructions/update.rs
+
+use core::slice::from_raw_parts;
+
+use pinocchio::{
+    account_info::AccountInfo,
+    instruction::{AccountMeta, Instruction, Signer},
+    program::invoke_signed,
+    pubkey::Pubkey,
+    ProgramResult,
+};
+
+use crate::UNINIT_BYTE;
+use crate::extensions::metadata_pointer::state::encode_update_instruction_data;
+
+pub struct MetadataPointerUpdate<'a, 'b> {
+    /// The mint to update.
+    pub mint: &'a AccountInfo,
+    /// Current metadata pointer authority (must sign).
+    pub authority: &'a AccountInfo,
+    /// New metadata address (None to clear).
+    pub new_metadata_address: Option<&'a Pubkey>,
+    /// Token program (Token-2022).
+    pub token_program: &'b Pubkey,
+}
+
+impl MetadataPointerUpdate<'_, '_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        // Account meta layout
+        let account_metas = [
+            AccountMeta::writable(self.mint.key()),
+            AccountMeta::readonly_signer(self.authority.key()),
+        ];
+
+        // Encode: [39, 1, new_metadata_address(32)]
+        let mut instruction_data = [UNINIT_BYTE; 34];
+        let written =
+            encode_update_instruction_data(&mut instruction_data, self.new_metadata_address);
+
+        let ix = Instruction {
+            program_id: self.token_program,
+            accounts: &account_metas,
+            data: unsafe { from_raw_parts(instruction_data.as_ptr() as _, written) },
+        };
+
+        invoke_signed(&ix, &[self.mint, self.authority], signers)
+    }
+}

--- a/programs/token-2022/src/extensions/metadata_pointer/mod.rs
+++ b/programs/token-2022/src/extensions/metadata_pointer/mod.rs
@@ -1,0 +1,3 @@
+pub mod state;
+pub mod instructions;
+

--- a/programs/token-2022/src/extensions/metadata_pointer/state.rs
+++ b/programs/token-2022/src/extensions/metadata_pointer/state.rs
@@ -1,0 +1,73 @@
+use crate::write_bytes;
+use core::mem::MaybeUninit;
+use pinocchio::pubkey::Pubkey;
+
+/// Sub-instruction for the Token-2022 Metadata Pointer extension.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MetadataPointerInstruction {
+    /// Require metadata pointers for transfers into this Account.
+    Initialize = 0,
+    /// Stop requiring metadata pointers for transfers into this Account.
+    Update = 1,
+}
+
+/// Metadata Pointer Extension discriminator (matches Token-2022)
+pub const METADATA_POINTER_EXTENSION_DISCRIMINATOR: u8 = 39;
+
+fn write_optional_pubkey(
+    destination: &mut [MaybeUninit<u8>],
+    pubkey: Option<&Pubkey>,
+) -> usize {
+    match pubkey {
+        Some(pk) => {
+            write_bytes(&mut destination[0..32], pk);
+        }
+        None => {
+            write_bytes(&mut destination[0..32], &[0u8; 32]);
+        }
+    }
+    32
+}
+
+
+/// Encode data for `Initialize`.
+/// Layout:
+/// - [0]: extension discriminator (u8 = 39)
+/// - [1]: sub-instruction (u8 = 0)
+/// - [2..34]: authority (OptionalNonZeroPubkey -> 32 bytes; zeros if None)
+/// - [34..66]: metadata_address (OptionalNonZeroPubkey -> 32 bytes; zeros if None)
+#[inline(always)]
+pub fn encode_initialize_instruction_data(
+    out: &mut [MaybeUninit<u8>],
+    authority: Option<&Pubkey>,
+    metadata_address: Option<&Pubkey>,
+) -> usize {
+    debug_assert!(out.len() >= 66);
+
+    write_bytes(&mut out[0..1], &[METADATA_POINTER_EXTENSION_DISCRIMINATOR]);
+    write_bytes(&mut out[1..2], &[MetadataPointerInstruction::Initialize as u8]);
+    write_optional_pubkey(&mut out[2..34], authority);
+    write_optional_pubkey(&mut out[34..66], metadata_address);
+
+    66
+}
+
+/// Encode data for `Update`.
+/// Layout:
+/// - [0]: extension discriminator (u8 = 39)
+/// - [1]: sub-instruction (u8 = 1)
+/// - [2..34]: new metadata_address (OptionalNonZeroPubkey -> 32 bytes; zeros if None)
+#[inline(always)]
+pub fn encode_update_instruction_data(
+    out: &mut [MaybeUninit<u8>],
+    new_metadata_address: Option<&Pubkey>,
+) -> usize {
+    debug_assert!(out.len() >= 34);
+
+    write_bytes(&mut out[0..1], &[METADATA_POINTER_EXTENSION_DISCRIMINATOR]);
+    write_bytes(&mut out[1..2], &[MetadataPointerInstruction::Update as u8]);
+    write_optional_pubkey(&mut out[2..34], new_metadata_address);
+
+    34
+}

--- a/programs/token-2022/src/extensions/mod.rs
+++ b/programs/token-2022/src/extensions/mod.rs
@@ -1,0 +1,1 @@
+pub mod metadata_pointer;

--- a/programs/token-2022/src/lib.rs
+++ b/programs/token-2022/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod instructions;
 pub mod state;
+pub mod extensions;
 
 pinocchio_pubkey::declare_id!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
 


### PR DESCRIPTION
This PR adds a Pinocchio-compatible implementation of the Metadata Pointer extension for Token-2022. It provides CPI wrappers and data encoders for:

- Initialize (set optional authority + optional metadata address)
- Update (set/clear metadata address)