### PR TITLE
test(group_pointer): verify Proxy target's state after clearing group pointer

### DIFF
--- a/cpi-tests/tests/src/group_pointer.rs
+++ b/cpi-tests/tests/src/group_pointer.rs
@@ -238,6 +238,14 @@ fn proxy_initialize_and_update_group_pointer() -> TestResult<()> {
         }
     );
 
+    assert_eq!(
+        app.token_2022_query_group_pointer(Target::Proxy, mint_pubkey)?,
+        GroupPointer {
+            authority: OptionalNonZeroPubkey(pin_pubkey_to_addr(&mint_authority.pubkey())),
+            group_address: OptionalNonZeroPubkey::default(),
+        }
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
**Key Updates:**

- The test `proxy_initialize_and_update_group_pointer()` previously only verified the state transition after clearing the group pointer for only `Target::Spl`.
- Therefore, added an assertion to also check the state for `Target::Proxy`.

**Note:**
- All tests are passing correctly
