### PR TITLE
feat(memo_transfer): full extension + proxy support with tests and token account helper

### DIFF
--- a/cpi-tests/programs/token-2022-proxy/src/instructions/initialize_token_account.rs
+++ b/cpi-tests/programs/token-2022-proxy/src/instructions/initialize_token_account.rs
@@ -1,0 +1,19 @@
+use {
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    pinocchio_token_2022,
+};
+
+pub fn initialize_token_account(accounts: &[AccountInfo]) -> ProgramResult {
+    let [token_account, mint, owner, rent_sysvar, token_program] = accounts else {
+        Err(ProgramError::InvalidAccountData)?
+    };
+
+    pinocchio_token_2022::instructions::InitializeAccount {
+        account: token_account,
+        mint,
+        owner,
+        rent_sysvar,
+        token_program: token_program.key(),
+    }
+    .invoke()
+}

--- a/cpi-tests/programs/token-2022-proxy/src/instructions/memo_transfer/disable.rs
+++ b/cpi-tests/programs/token-2022-proxy/src/instructions/memo_transfer/disable.rs
@@ -22,8 +22,8 @@ pub fn disable(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResu
     let token_program = accounts.last().unwrap(); // dev : since token_program is always the last account
     let signers = &accounts[2..accounts.len() - 1]; // dev : everything between authority and token_program ; note : in Single authority case: [2..2] will result in empty array
 
-    match instruction_data[1] {
-        // dev: byte at index 1 = Action Type; 1 = Disable
+    match instruction_data[0] {
+        // dev: use index 0 — lib.rs already strips the first byte (extension tag) from original instruction data; value `1` = Disable.
         1 => pinocchio_token_2022::extension::memo_transfer::Disable {
             token_account,
             authority,

--- a/cpi-tests/programs/token-2022-proxy/src/instructions/memo_transfer/disable.rs
+++ b/cpi-tests/programs/token-2022-proxy/src/instructions/memo_transfer/disable.rs
@@ -1,0 +1,37 @@
+use {
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    pinocchio_token_2022,
+};
+
+pub fn disable(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
+    // Expected account layout:
+    //   [ token_account, authority/owner , ...signers, token_program ]
+    //
+    // Single authority case:
+    //   [ token_account, authority/owner (signer), token_program ]
+    //
+    // Multisig case:
+    //   [ token_account, authority/owner , signer1, signer2, ... signer n, token_program ]
+
+    if accounts.len() < 3 {
+        Err(ProgramError::NotEnoughAccountKeys)?;
+    }
+
+    let token_account = &accounts[0];
+    let authority = &accounts[1];
+    let token_program = accounts.last().unwrap(); // dev : since token_program is always the last account
+    let signers = &accounts[2..accounts.len() - 1]; // dev : everything between authority and token_program ; note : in Single authority case: [2..2] will result in empty array
+
+    match instruction_data[1] {
+        // dev: byte at index 1 = Action Type; 1 = Disable
+        1 => pinocchio_token_2022::extension::memo_transfer::Disable {
+            token_account,
+            authority,
+            signers,
+            token_program: token_program.key(),
+        }
+        .invoke(),
+
+        _ => return Err(ProgramError::InvalidInstructionData),
+    }
+}

--- a/cpi-tests/programs/token-2022-proxy/src/instructions/memo_transfer/enable.rs
+++ b/cpi-tests/programs/token-2022-proxy/src/instructions/memo_transfer/enable.rs
@@ -1,0 +1,37 @@
+use {
+    pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult},
+    pinocchio_token_2022,
+};
+
+pub fn enable(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
+    // Expected account layout:
+    //   [ token_account, authority/owner , ...signers, token_program ]
+    //
+    // Single authority case:
+    //   [ token_account, authority/owner (signer), token_program ]
+    //
+    // Multisig case:
+    //   [ token_account, authority/owner , signer1, signer2, ... signer n, token_program ]
+
+    if accounts.len() < 3 {
+        Err(ProgramError::NotEnoughAccountKeys)?;
+    }
+
+    let token_account = &accounts[0];
+    let authority = &accounts[1];
+    let token_program = accounts.last().unwrap(); // dev : since token_program is always the last account
+    let signers = &accounts[2..accounts.len() - 1]; // dev : everything between authority and token_program ; note : in Single authority case: [2..2] will result in empty array
+
+    match instruction_data[1] {
+        // dev: byte at index 1 = Action Type; 0 = Enable
+        0 => pinocchio_token_2022::extension::memo_transfer::Enable {
+            token_account,
+            authority,
+            signers,
+            token_program: token_program.key(),
+        }
+        .invoke(),
+
+        _ => return Err(ProgramError::InvalidInstructionData),
+    }
+}

--- a/cpi-tests/programs/token-2022-proxy/src/instructions/memo_transfer/enable.rs
+++ b/cpi-tests/programs/token-2022-proxy/src/instructions/memo_transfer/enable.rs
@@ -22,8 +22,8 @@ pub fn enable(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResul
     let token_program = accounts.last().unwrap(); // dev : since token_program is always the last account
     let signers = &accounts[2..accounts.len() - 1]; // dev : everything between authority and token_program ; note : in Single authority case: [2..2] will result in empty array
 
-    match instruction_data[1] {
-        // dev: byte at index 1 = Action Type; 0 = Enable
+    match instruction_data[0] {
+        // dev: use index 0 — lib.rs already strips the first byte (extension tag) from original instruction data ; value `0` = Enable.
         0 => pinocchio_token_2022::extension::memo_transfer::Enable {
             token_account,
             authority,

--- a/cpi-tests/programs/token-2022-proxy/src/instructions/memo_transfer/mod.rs
+++ b/cpi-tests/programs/token-2022-proxy/src/instructions/memo_transfer/mod.rs
@@ -1,0 +1,4 @@
+mod disable;
+mod enable;
+
+pub use {disable::*, enable::*};

--- a/cpi-tests/programs/token-2022-proxy/src/instructions/mod.rs
+++ b/cpi-tests/programs/token-2022-proxy/src/instructions/mod.rs
@@ -1,6 +1,6 @@
 pub mod group_member_pointer;
 pub mod group_pointer;
-// pub mod memo_transfer;
+pub mod memo_transfer;
 pub mod token_group;
 
 mod initialize_mint;

--- a/cpi-tests/programs/token-2022-proxy/src/instructions/mod.rs
+++ b/cpi-tests/programs/token-2022-proxy/src/instructions/mod.rs
@@ -1,9 +1,12 @@
 pub mod group_member_pointer;
 pub mod group_pointer;
+// pub mod memo_transfer;
 pub mod token_group;
 
 mod initialize_mint;
 mod initialize_permanent_delegate;
+mod initialize_token_account;
 
 pub use initialize_mint::initialize_mint;
 pub use initialize_permanent_delegate::initialize_permanent_delegate;
+pub use initialize_token_account::initialize_token_account;

--- a/cpi-tests/programs/token-2022-proxy/src/lib.rs
+++ b/cpi-tests/programs/token-2022-proxy/src/lib.rs
@@ -11,6 +11,7 @@ use {
         extension::{
             group_member_pointer::instruction::GroupMemberPointerInstruction,
             group_pointer::instruction::GroupPointerInstruction,
+            memo_transfer::instruction::RequiredMemoTransfersInstruction
         },
         instruction::{decode_instruction_type, TokenInstruction},
     },
@@ -79,6 +80,23 @@ pub fn process_instruction(
 
                 TokenInstruction::InitializePermanentDelegate { delegate } => {
                     initialize_permanent_delegate(accounts, delegate)
+                }
+
+                // MemoTransfer Extention
+                TokenInstruction::MemoTransferExtension => {
+                    let instruction_data = &instruction_data[1..]; // Remove extension discriminator
+                    let ix: RequiredMemoTransfersInstruction =
+                        decode_instruction_type(instruction_data)
+                            .map_err(|_| ProgramError::InvalidInstructionData)?;
+
+                    match ix {
+                        RequiredMemoTransfersInstruction::Enable => {
+                            i::memo_transfer::enable(accounts, instruction_data)
+                        }
+                        RequiredMemoTransfersInstruction::Disable => {
+                            i::memo_transfer::disable(accounts, instruction_data)
+                        }
+                    }
                 }
 
                 _ => Err(ProgramError::InvalidInstructionData)?,

--- a/cpi-tests/programs/token-2022-proxy/src/lib.rs
+++ b/cpi-tests/programs/token-2022-proxy/src/lib.rs
@@ -43,6 +43,9 @@ pub fn process_instruction(
                     freeze_authority,
                 } => i::initialize_mint(accounts, decimals, mint_authority, freeze_authority),
 
+                // For Initializing TokenAccount
+                TokenInstruction::InitializeAccount => i::initialize_token_account(accounts),
+
                 TokenInstruction::GroupPointerExtension => {
                     let instruction_data = &instruction_data[1..]; // Remove extension discriminator
                     let ix: GroupPointerInstruction = decode_instruction_type(instruction_data)

--- a/cpi-tests/tests/src/helpers/extensions/token_2022/initialize_token_account.rs
+++ b/cpi-tests/tests/src/helpers/extensions/token_2022/initialize_token_account.rs
@@ -1,0 +1,196 @@
+use {
+    crate::helpers::suite::{
+        core::{
+            extension::{get_account_data, send_tx},
+            App, ProgramId,
+        },
+        types::{
+            addr_to_sol_pubkey, pin_pubkey_to_addr, to_c_option, AppUser, Target, TestError,
+            TestResult,
+        },
+    },
+    litesvm::types::TransactionMetadata,
+    pinocchio::pubkey::Pubkey,
+    pinocchio_token_2022::state::{
+        AccountState as PinocchioAccountState, TokenAccount as PinocchioTokenAccount,
+    },
+    solana_keypair::Keypair,
+    solana_program_pack::Pack,
+    spl_token_2022_interface::{
+        extension::ExtensionType,
+        state::{Account, AccountState as SplAccountState},
+    },
+};
+
+pub trait Token2022InitializeAccountExtension {
+    fn token_2022_try_create_token_account(
+        &mut self,
+        sender: AppUser,
+        account: Option<Keypair>,
+        extensions: Option<&[ExtensionType]>,
+    ) -> TestResult<(TransactionMetadata, Keypair)>;
+
+    fn token_2022_try_initialize_token_account(
+        &mut self,
+        target: Target,
+        sender: AppUser,
+        account: &Pubkey,
+        mint: &Pubkey,
+        owner: &Pubkey,
+    ) -> TestResult<TransactionMetadata>;
+
+    fn token_2022_query_token_account(
+        &self,
+        target: Target,
+        account: &Pubkey,
+    ) -> TestResult<Account>;
+
+    fn token2022_try_create_and_try_initialize_mint(
+        &mut self,
+        target: Target,
+    ) -> TestResult<(TransactionMetadata, Pubkey)>;
+}
+
+impl Token2022InitializeAccountExtension for App {
+    fn token_2022_try_create_token_account(
+        &mut self,
+        sender: AppUser,
+        account: Option<Keypair>,
+        extensions: Option<&[ExtensionType]>,
+    ) -> TestResult<(TransactionMetadata, Keypair)> {
+        let ProgramId {
+            token_2022_program, ..
+        } = self.program_id;
+
+        let account_size = match extensions {
+            Some(extention_type) => {
+                ExtensionType::try_calculate_account_len::<Account>(extention_type)
+                    .map_err(TestError::from_raw_error)?
+            }
+            None => Account::LEN,
+        };
+
+        self.create_account(sender, account, account_size, &token_2022_program)
+    }
+
+    fn token_2022_try_initialize_token_account(
+        &mut self,
+        target: Target,
+        sender: AppUser,
+        account: &Pubkey,
+        mint: &Pubkey,
+        owner: &Pubkey,
+    ) -> TestResult<TransactionMetadata> {
+        let ProgramId {
+            token_2022_program,
+            token_2022_proxy,
+            ..
+        } = self.program_id;
+
+        let signers = &[sender.keypair()];
+
+        let ix = spl_token_2022_interface::instruction::initialize_account(
+            &token_2022_program.to_bytes().into(),
+            &pin_pubkey_to_addr(account),
+            &pin_pubkey_to_addr(mint),
+            &pin_pubkey_to_addr(owner),
+        )
+        .map_err(TestError::from_raw_error)?;
+
+        let additional_accounts = [solana_instruction::AccountMeta::new_readonly(
+            token_2022_program,
+            false,
+        )];
+
+        let mut ix_legacy = solana_instruction::Instruction {
+            program_id: addr_to_sol_pubkey(&ix.program_id),
+            accounts: ix
+                .accounts
+                .into_iter()
+                .map(|x| solana_instruction::AccountMeta {
+                    pubkey: addr_to_sol_pubkey(&x.pubkey),
+                    is_signer: x.is_signer,
+                    is_writable: x.is_writable,
+                })
+                .collect(),
+            data: ix.data,
+        };
+
+        if let Target::Proxy = target {
+            ix_legacy.program_id = token_2022_proxy;
+            ix_legacy.accounts.extend_from_slice(&additional_accounts);
+        }
+
+        send_tx(
+            &mut self.litesvm,
+            &[ix_legacy],
+            signers,
+            self.is_log_displayed,
+        )
+    }
+
+    fn token_2022_query_token_account(
+        &self,
+        target: Target,
+        account: &Pubkey,
+    ) -> TestResult<Account> {
+        let data = &get_account_data(self, account)?;
+
+        match target {
+            Target::Spl => Account::unpack_from_slice(data).map_err(TestError::from_raw_error),
+            Target::Proxy => {
+                let state = unsafe { PinocchioTokenAccount::from_bytes_unchecked(data) };
+
+                Ok(Account {
+                    mint: pin_pubkey_to_addr(&state.mint()),
+                    owner: pin_pubkey_to_addr(&state.owner()),
+                    amount: state.amount(),
+                    delegate: to_c_option(state.delegate().map(pin_pubkey_to_addr)),
+
+                    state: match state.state() {
+                        PinocchioAccountState::Uninitialized => SplAccountState::Uninitialized,
+                        PinocchioAccountState::Initialized => SplAccountState::Initialized,
+                        PinocchioAccountState::Frozen => SplAccountState::Frozen,
+                    },
+                    is_native: to_c_option(Some(state.is_native() as u64)), // dev :: Some(0) -> False ; Some(1)
+                    delegated_amount: state.delegated_amount(),
+                    close_authority: to_c_option(state.close_authority().map(pin_pubkey_to_addr)),
+                })
+            }
+        }
+    }
+
+    /// dev: quickly create and initialize a mint; returns (TransactionMetadata, mint pubkey)
+    fn token2022_try_create_and_try_initialize_mint(
+        &mut self,
+        target: Target,
+    ) -> TestResult<(TransactionMetadata, Pubkey)> {
+        use {
+            crate::helpers::{
+                extensions::token_2022::initialize_mint::Token2022InitializeMintExtension,
+                suite::types::SolPubkey,
+            },
+            solana_signer::Signer,
+        };
+
+        let (_, mint_keypair) =
+            self.token_2022_try_create_mint_account(AppUser::Admin, None, None)?;
+
+        let mint = &mint_keypair.pubkey().to_bytes();
+        let decimals: u8 = 6;
+        let mint_authority = AppUser::Admin.pubkey().to_bytes();
+        let freeze_authority = Some(AppUser::Bob.pubkey().to_bytes());
+        Ok((
+            self.token_2022_try_initialize_mint(
+                target,
+                AppUser::Admin,
+                mint,
+                decimals,
+                &mint_authority,
+                freeze_authority.as_ref(),
+            )
+            .unwrap(),
+            mint.clone(),
+        ))
+    }
+}

--- a/cpi-tests/tests/src/helpers/extensions/token_2022/memo_transfer.rs
+++ b/cpi-tests/tests/src/helpers/extensions/token_2022/memo_transfer.rs
@@ -1,0 +1,324 @@
+use {
+    crate::helpers::suite::{
+        core::{extension::send_tx, App, ProgramId},
+        types::{
+            addr_to_sol_pubkey, pin_pubkey_to_addr, AppUser, SolPubkey, Target, TestError,
+            TestResult,
+        },
+    },
+    litesvm::types::TransactionMetadata,
+    pinocchio::pubkey::Pubkey,
+    solana_address::Address,
+    solana_keypair::Keypair,
+};
+
+pub trait Token2022MemoTransferExtension {
+    fn token_2022_try_enable_memo_transfer(
+        &mut self,
+        target: Target,
+        token_account: &Pubkey,
+        authority: &Pubkey,
+        signer: AppUser,
+    ) -> TestResult<TransactionMetadata>;
+
+    fn token_2022_try_enable_memo_transfer_multisig(
+        &mut self,
+        target: Target,
+        token_account: &Pubkey,
+        multisig_authority: &Pubkey,
+        signers: &[AppUser],
+    ) -> TestResult<TransactionMetadata>;
+
+    fn token_2022_try_disable_memo_transfer(
+        &mut self,
+        target: Target,
+        token_account: &Pubkey,
+        authority: &Pubkey,
+        signer: AppUser,
+    ) -> TestResult<TransactionMetadata>;
+
+    fn token_2022_try_disable_memo_transfer_multisig(
+        &mut self,
+        target: Target,
+        token_account: &Pubkey,
+        multisig_authority: &Pubkey,
+        signers: &[AppUser],
+    ) -> TestResult<TransactionMetadata>;
+}
+
+impl Token2022MemoTransferExtension for App {
+    fn token_2022_try_enable_memo_transfer(
+        &mut self,
+        target: Target,
+        token_account: &Pubkey,
+        authority: &Pubkey,
+        signer: AppUser,
+    ) -> TestResult<TransactionMetadata> {
+        let ProgramId {
+            token_2022_program,
+            token_2022_proxy,
+            ..
+        } = self.program_id;
+
+        let signers = &[&signer.keypair()];
+        let authority_signers = &[&pin_pubkey_to_addr(&signer.pubkey().to_bytes())];
+
+        let ix = spl_token_2022_interface::extension::memo_transfer::instruction::enable_required_transfer_memos(
+            &token_2022_program.to_bytes().into(),
+            &pin_pubkey_to_addr(token_account),
+            &pin_pubkey_to_addr(authority),
+            authority_signers,
+        )
+        .map_err(TestError::from_raw_error)?;
+
+        let additional_accounts = [solana_instruction::AccountMeta::new_readonly(
+            token_2022_program,
+            false,
+        )];
+
+        let mut ix_legacy = solana_instruction::Instruction {
+            program_id: addr_to_sol_pubkey(&ix.program_id),
+            accounts: ix
+                .accounts
+                .into_iter()
+                .map(|x| solana_instruction::AccountMeta {
+                    pubkey: addr_to_sol_pubkey(&x.pubkey),
+                    is_signer: x.is_signer,
+                    is_writable: x.is_writable,
+                })
+                .collect(),
+            data: ix.data,
+        };
+
+        if let Target::Proxy = target {
+            ix_legacy.program_id = token_2022_proxy;
+            ix_legacy.accounts.extend_from_slice(&additional_accounts);
+        }
+
+        send_tx(
+            &mut self.litesvm,
+            &[ix_legacy],
+            signers,
+            self.is_log_displayed,
+        )
+    }
+
+    fn token_2022_try_enable_memo_transfer_multisig(
+        &mut self,
+        target: Target,
+        token_account: &Pubkey,
+        multisig_authority: &Pubkey,
+        signers: &[AppUser],
+    ) -> TestResult<TransactionMetadata> {
+        let ProgramId {
+            token_2022_program,
+            token_2022_proxy,
+            ..
+        } = self.program_id;
+
+        let (signers_keypairs, authority_signers) = extract_signers_and_authorities(signers);
+        let authority_refs: Vec<_> = authority_signers.iter().collect();
+
+        let ix = spl_token_2022_interface::extension::memo_transfer::instruction::enable_required_transfer_memos(
+            &token_2022_program.to_bytes().into(),
+            &pin_pubkey_to_addr(token_account),
+            &pin_pubkey_to_addr(multisig_authority),
+            &authority_refs,
+        )
+        .map_err(TestError::from_raw_error)?;
+
+        let additional_accounts = [solana_instruction::AccountMeta::new_readonly(
+            token_2022_program,
+            false,
+        )];
+
+        let mut ix_legacy = solana_instruction::Instruction {
+            program_id: addr_to_sol_pubkey(&ix.program_id),
+            accounts: ix
+                .accounts
+                .into_iter()
+                .map(|x| solana_instruction::AccountMeta {
+                    pubkey: addr_to_sol_pubkey(&x.pubkey),
+                    is_signer: x.is_signer,
+                    is_writable: x.is_writable,
+                })
+                .collect(),
+            data: ix.data,
+        };
+
+        if let Target::Proxy = target {
+            ix_legacy.program_id = token_2022_proxy;
+            ix_legacy.accounts.extend_from_slice(&additional_accounts);
+        }
+
+        send_tx(
+            &mut self.litesvm,
+            &[ix_legacy],
+            &signers_keypairs,
+            self.is_log_displayed,
+        )
+    }
+
+    fn token_2022_try_disable_memo_transfer(
+        &mut self,
+        target: Target,
+        token_account: &Pubkey,
+        authority: &Pubkey,
+        signer: AppUser,
+    ) -> TestResult<TransactionMetadata> {
+        let ProgramId {
+            token_2022_program,
+            token_2022_proxy,
+            ..
+        } = self.program_id;
+
+        let signers = &[&signer.keypair()];
+        let authority_signers = &[&pin_pubkey_to_addr(&signer.pubkey().to_bytes())];
+
+        let ix = spl_token_2022_interface::extension::memo_transfer::instruction::disable_required_transfer_memos(
+            &token_2022_program.to_bytes().into(),
+            &pin_pubkey_to_addr(token_account),
+            &pin_pubkey_to_addr(authority),
+            authority_signers,
+        )
+        .map_err(TestError::from_raw_error)?;
+
+        let additional_accounts = [solana_instruction::AccountMeta::new_readonly(
+            token_2022_program,
+            false,
+        )];
+
+        let mut ix_legacy = solana_instruction::Instruction {
+            program_id: addr_to_sol_pubkey(&ix.program_id),
+            accounts: ix
+                .accounts
+                .into_iter()
+                .map(|x| solana_instruction::AccountMeta {
+                    pubkey: addr_to_sol_pubkey(&x.pubkey),
+                    is_signer: x.is_signer,
+                    is_writable: x.is_writable,
+                })
+                .collect(),
+            data: ix.data,
+        };
+
+        if let Target::Proxy = target {
+            ix_legacy.program_id = token_2022_proxy;
+            ix_legacy.accounts.extend_from_slice(&additional_accounts);
+        }
+
+        send_tx(
+            &mut self.litesvm,
+            &[ix_legacy],
+            signers,
+            self.is_log_displayed,
+        )
+    }
+
+    fn token_2022_try_disable_memo_transfer_multisig(
+        &mut self,
+        target: Target,
+        token_account: &Pubkey,
+        multisig_authority: &Pubkey,
+        signers: &[AppUser],
+    ) -> TestResult<TransactionMetadata> {
+        let ProgramId {
+            token_2022_program,
+            token_2022_proxy,
+            ..
+        } = self.program_id;
+
+        let (signers_keypairs, authority_signers) = extract_signers_and_authorities(signers);
+        let authority_refs: Vec<_> = authority_signers.iter().collect();
+
+        let ix = spl_token_2022_interface::extension::memo_transfer::instruction::disable_required_transfer_memos(
+            &token_2022_program.to_bytes().into(),
+            &pin_pubkey_to_addr(token_account),
+            &pin_pubkey_to_addr(multisig_authority),
+            &authority_refs,
+        )
+        .map_err(TestError::from_raw_error)?;
+
+        let additional_accounts = [solana_instruction::AccountMeta::new_readonly(
+            token_2022_program,
+            false,
+        )];
+
+        let mut ix_legacy = solana_instruction::Instruction {
+            program_id: addr_to_sol_pubkey(&ix.program_id),
+            accounts: ix
+                .accounts
+                .into_iter()
+                .map(|x| solana_instruction::AccountMeta {
+                    pubkey: addr_to_sol_pubkey(&x.pubkey),
+                    is_signer: x.is_signer,
+                    is_writable: x.is_writable,
+                })
+                .collect(),
+            data: ix.data,
+        };
+
+        if let Target::Proxy = target {
+            ix_legacy.program_id = token_2022_proxy;
+            ix_legacy.accounts.extend_from_slice(&additional_accounts);
+        }
+
+        send_tx(
+            &mut self.litesvm,
+            &[ix_legacy],
+            &signers_keypairs,
+            self.is_log_displayed,
+        )
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////HELPERS/////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// dev : data[165..171] holds memo_transfer extention bytes; 165 = base token_account len, 171 = total with extention
+#[derive(Debug, PartialEq, Eq)]
+pub enum MemoStatus {
+    /// [2, 0, 0, 0, 0, 0]
+    /// Represents a MemoTransfer extension that has been initialized
+    /// but not yet toggled to enforce memos on transfers.
+    Initialized,
+
+    /// [2, 8, 0, 1, 0, 1]
+    /// Memo enforcement is active; transfers must include a memo instruction.
+    Enabled,
+
+    /// [2, 8, 0, 1, 0, 0]
+    /// Memo enforcement disabled; transfers without memos are allowed.
+    Disabled,
+
+    /// [ Invalid Bytes ]
+    /// Any other byte pattern, indicates data corruption or invalid state.
+    Invalid,
+}
+
+impl MemoStatus {
+    /// dev: just checks the 6-byte slice from [165..171] to figure out memo state
+    pub fn check_memo_status(memo_data_slice: &[u8]) -> MemoStatus {
+        match memo_data_slice {
+            [2, 0, 0, 0, 0, 0] => MemoStatus::Initialized,
+            [2, 8, 0, 1, 0, 1] => MemoStatus::Enabled,
+            [2, 8, 0, 1, 0, 0] => MemoStatus::Disabled,
+            _ => MemoStatus::Invalid,
+        }
+    }
+}
+
+/// Extracts signer keypairs and authority addresses from a list of AppUsers.
+/// Returns a tuple `(signer_keypairs, authority_addresses)`.
+fn extract_signers_and_authorities<'a>(signers: &'a [AppUser]) -> (Vec<Keypair>, Vec<Address>) {
+    let mut signer_keypairs = Vec::new();
+    let mut authority_addrs = Vec::new();
+
+    for s in signers {
+        signer_keypairs.push(s.keypair());
+        authority_addrs.push(pin_pubkey_to_addr(&s.pubkey().to_bytes()));
+    }
+
+    (signer_keypairs, authority_addrs)
+}

--- a/cpi-tests/tests/src/initialize_token_account.rs
+++ b/cpi-tests/tests/src/initialize_token_account.rs
@@ -44,9 +44,6 @@ pub fn create_and_initialize_token_account() -> TestResult<()> {
     Ok(())
 }
 
-/// TODO: error — `TestError { info: "invalid instruction data", index: None }`  
-/// TODO: cause — issue in building/dispatching `Target::Proxy` instructions, account data is fine.
-/// TODO: debug how proxy instructions are actually built and sent in this test.
 #[test]
 pub fn proxy_create_and_initialize_token_account() -> TestResult<()> {
     let mut app = App::new(false);

--- a/cpi-tests/tests/src/initialize_token_account.rs
+++ b/cpi-tests/tests/src/initialize_token_account.rs
@@ -1,0 +1,80 @@
+use {
+    crate::helpers::{
+        extensions::token_2022::initialize_token_account::Token2022InitializeAccountExtension,
+        suite::{
+            core::App,
+            types::{AppUser, PinPubkey, Target, TestResult},
+        },
+    },
+    pretty_assertions::assert_eq,
+    solana_program_pack::IsInitialized,
+    solana_signer::Signer,
+    spl_token_2022_interface::extension::ExtensionType,
+};
+
+#[test]
+pub fn create_and_initialize_token_account() -> TestResult<()> {
+    let mut app = App::new(false);
+
+    let (_, mint) = app.token2022_try_create_and_try_initialize_mint(Target::Spl)?;
+
+    let (_, token_account_keypair) = app.token_2022_try_create_token_account(
+        AppUser::Admin,
+        None,
+        Some(&[ExtensionType::MemoTransfer]),
+    )?;
+    let token_account = token_account_keypair.pubkey().to_bytes();
+    let alice = AppUser::Alice.pubkey();
+
+    app.token_2022_try_initialize_token_account(
+        Target::Spl,
+        AppUser::Admin,
+        &token_account,
+        &mint,
+        &alice,
+    )?;
+
+    let token_account_data = app.token_2022_query_token_account(Target::Spl, &token_account)?;
+
+    //// Assertions
+    assert!(token_account_data.is_initialized());
+    assert_eq!(token_account_data.mint.to_bytes(), mint);
+    assert_eq!(token_account_data.owner.to_bytes(), alice);
+
+    Ok(())
+}
+
+/// TODO: error — `TestError { info: "invalid instruction data", index: None }`  
+/// TODO: cause — issue in building/dispatching `Target::Proxy` instructions, account data is fine.
+/// TODO: debug how proxy instructions are actually built and sent in this test.
+#[test]
+pub fn proxy_create_and_initialize_token_account() -> TestResult<()> {
+    let mut app = App::new(false);
+
+    let (_, mint) = app.token2022_try_create_and_try_initialize_mint(Target::Proxy)?;
+
+    let (_, token_account_keypair) = app.token_2022_try_create_token_account(
+        AppUser::Admin,
+        None,
+        Some(&[ExtensionType::MemoTransfer]),
+    )?;
+    let token_account = token_account_keypair.pubkey().to_bytes();
+    let alice = AppUser::Alice.pubkey();
+
+    app.token_2022_try_initialize_token_account(
+        Target::Proxy,
+        AppUser::Admin,
+        &token_account,
+        &mint,
+        &alice,
+    )?;
+
+    let token_account_data = app.token_2022_query_token_account(Target::Proxy, &token_account)?;
+
+    //// Assertions
+    assert!(token_account_data.is_initialized());
+    assert_eq!(token_account_data.mint.to_bytes(), mint);
+    assert_eq!(token_account_data.owner.to_bytes(), alice);
+
+    Ok(())
+}

--- a/cpi-tests/tests/src/lib.rs
+++ b/cpi-tests/tests/src/lib.rs
@@ -18,6 +18,7 @@ pub mod helpers {
             pub mod group_pointer;
             pub mod initialize_mint;
             pub mod initialize_multisig;
+            pub mod initialize_token_account;
             pub mod permanent_delegate;
             pub mod token_group;
         }

--- a/cpi-tests/tests/src/lib.rs
+++ b/cpi-tests/tests/src/lib.rs
@@ -7,6 +7,8 @@ pub mod initialize_mint;
 #[cfg(test)]
 pub mod initialize_token_account;
 #[cfg(test)]
+pub mod memo_transfer;
+#[cfg(test)]
 pub mod permanent_delegate;
 #[cfg(test)]
 pub mod token_group;
@@ -21,6 +23,7 @@ pub mod helpers {
             pub mod initialize_mint;
             pub mod initialize_multisig;
             pub mod initialize_token_account;
+            pub mod memo_transfer;
             pub mod permanent_delegate;
             pub mod token_group;
         }

--- a/cpi-tests/tests/src/lib.rs
+++ b/cpi-tests/tests/src/lib.rs
@@ -5,6 +5,8 @@ pub mod group_pointer;
 #[cfg(test)]
 pub mod initialize_mint;
 #[cfg(test)]
+pub mod initialize_token_account;
+#[cfg(test)]
 pub mod permanent_delegate;
 #[cfg(test)]
 pub mod token_group;

--- a/cpi-tests/tests/src/memo_transfer.rs
+++ b/cpi-tests/tests/src/memo_transfer.rs
@@ -206,8 +206,197 @@ fn disable_memo_transfer_with_multisig() -> TestResult<()> {
     Ok(())
 }
 
-//// TODO : Add Target::Proxy Tests :
-//// proxy_enable_memo_transfer_with_eoa
-//// proxy_enable_memo_transfer_with_multisig
-//// proxy_disable_memo_transfer_with_eoa
-//// proxy_disable_memo_transfer_with_multisig
+#[test]
+fn proxy_enable_memo_transfer_with_eoa() -> TestResult<()> {
+    let mut app = App::new(false);
+
+    let (_, mint) = app.token2022_try_create_and_try_initialize_mint(Target::Proxy)?;
+
+    let (_, token_account_keypair) = app.token_2022_try_create_token_account(
+        AppUser::Admin,
+        None,
+        Some(&[ExtensionType::MemoTransfer]),
+    )?;
+    let token_account = token_account_keypair.pubkey().to_bytes();
+    let alice = AppUser::Alice.pubkey();
+
+    app.token_2022_try_initialize_token_account(
+        Target::Proxy,
+        AppUser::Admin,
+        &token_account,
+        &mint,
+        &alice,
+    )?;
+
+    let mut token_account_raw_data = get_account_data(&app, &token_account)?;
+
+    // assertion
+    assert_eq!(
+        MemoStatus::check_memo_status(&token_account_raw_data[165..171]),
+        MemoStatus::Initialized
+    );
+
+    // Enable Memo
+    app.token_2022_try_enable_memo_transfer(Target::Proxy, &token_account, &alice, AppUser::Alice)?;
+    token_account_raw_data = get_account_data(&app, &token_account)?;
+
+    // assertion
+    assert_eq!(
+        MemoStatus::check_memo_status(&token_account_raw_data[165..171]),
+        MemoStatus::Enabled
+    );
+
+    Ok(())
+}
+
+#[test]
+fn proxy_enable_memo_transfer_with_multisig() -> TestResult<()> {
+    let mut app = App::new(true);
+    let (_, mint) = app.token2022_try_create_and_try_initialize_mint(Target::Proxy)?;
+
+    // create a multisig authority with 3 signers, requiring 2 signatures
+    let signer1 = AppUser::Admin;
+    let signer2 = AppUser::Alice;
+    let signer3 = AppUser::Bob;
+    let required_signers: u8 = 2;
+
+    let (_, multisig_kp) = app.token_2022_try_create_multisig(AppUser::Admin, None)?;
+    let multisig_pubkey: &[u8; 32] = &multisig_kp.pubkey().to_bytes().into();
+
+    app.token_2022_try_initialize_multisig(
+        Target::Spl, // dev: Using Target::Spl is fine here; routing through Proxy would need a dedicated InitializeMultisig helper.
+        AppUser::Admin,
+        multisig_pubkey,
+        required_signers,
+        &[signer1.pubkey(), signer2.pubkey(), signer3.pubkey()],
+    )?;
+
+    let (_, token_account_keypair) = app.token_2022_try_create_token_account(
+        AppUser::Admin,
+        None,
+        Some(&[ExtensionType::MemoTransfer]),
+    )?;
+    let token_account = token_account_keypair.pubkey().to_bytes();
+
+    app.token_2022_try_initialize_token_account(
+        Target::Proxy,
+        AppUser::Admin,
+        &token_account,
+        &mint,
+        &multisig_pubkey,
+    )?;
+
+    app.token_2022_try_enable_memo_transfer_multisig(
+        Target::Proxy,
+        &token_account,
+        &multisig_pubkey,
+        &[signer1, signer2],
+    )?;
+
+    let token_account_raw_data = get_account_data(&app, &token_account)?;
+    let memo_data_slice = &token_account_raw_data[165..171];
+
+    assert_eq!(
+        MemoStatus::check_memo_status(memo_data_slice),
+        MemoStatus::Enabled
+    );
+
+    Ok(())
+}
+
+#[test]
+fn proxy_disable_memo_transfer_with_eoa() -> TestResult<()> {
+    let mut app = App::new(false);
+
+    let (_, mint) = app.token2022_try_create_and_try_initialize_mint(Target::Proxy)?;
+
+    let (_, token_account_keypair) = app.token_2022_try_create_token_account(
+        AppUser::Admin,
+        None,
+        Some(&[ExtensionType::MemoTransfer]),
+    )?;
+    let token_account = token_account_keypair.pubkey().to_bytes();
+    let alice = AppUser::Alice.pubkey();
+
+    app.token_2022_try_initialize_token_account(
+        Target::Proxy,
+        AppUser::Admin,
+        &token_account,
+        &mint,
+        &alice,
+    )?;
+
+    app.token_2022_try_disable_memo_transfer(
+        Target::Proxy,
+        &token_account,
+        &alice,
+        AppUser::Alice,
+    )?;
+
+    let token_account_raw_data = get_account_data(&app, &token_account)?;
+    let memo_data_slice = &token_account_raw_data[165..171];
+
+    // assertion
+    assert_eq!(
+        MemoStatus::check_memo_status(memo_data_slice),
+        MemoStatus::Disabled
+    );
+
+    Ok(())
+}
+
+#[test]
+fn proxy_disable_memo_transfer_with_multisig() -> TestResult<()> {
+    let mut app = App::new(false);
+    let (_, mint) = app.token2022_try_create_and_try_initialize_mint(Target::Proxy)?;
+
+    // create a multisig authority with 3 signers, requiring 2 signatures
+    let signer1 = AppUser::Admin;
+    let signer2 = AppUser::Alice;
+    let signer3 = AppUser::Bob;
+    let required_signers: u8 = 2;
+
+    let (_, multisig_kp) = app.token_2022_try_create_multisig(AppUser::Admin, None)?;
+    let multisig_pubkey: &[u8; 32] = &multisig_kp.pubkey().to_bytes().into();
+    
+    app.token_2022_try_initialize_multisig(
+        Target::Spl, // dev: Using Target::Spl is fine here; routing through Proxy would need a dedicated InitializeMultisig helper.
+        AppUser::Admin,
+        multisig_pubkey,
+        required_signers,
+        &[signer1.pubkey(), signer2.pubkey(), signer3.pubkey()],
+    )?;
+
+    let (_, token_account_keypair) = app.token_2022_try_create_token_account(
+        AppUser::Admin,
+        None,
+        Some(&[ExtensionType::MemoTransfer]),
+    )?;
+    let token_account = token_account_keypair.pubkey().to_bytes();
+
+    app.token_2022_try_initialize_token_account(
+        Target::Proxy,
+        AppUser::Admin,
+        &token_account,
+        &mint,
+        &multisig_pubkey,
+    )?;
+
+    app.token_2022_try_disable_memo_transfer_multisig(
+        Target::Proxy,
+        &token_account,
+        &multisig_pubkey,
+        &[signer1, signer2],
+    )?;
+
+    let token_account_raw_data = get_account_data(&app, &token_account)?;
+    let memo_data_slice = &token_account_raw_data[165..171];
+
+    // assertion
+    assert_eq!(
+        MemoStatus::check_memo_status(memo_data_slice),
+        MemoStatus::Disabled
+    );
+
+    Ok(())
+}

--- a/cpi-tests/tests/src/memo_transfer.rs
+++ b/cpi-tests/tests/src/memo_transfer.rs
@@ -1,0 +1,213 @@
+use {
+    crate::helpers::{
+        extensions::token_2022::{
+            initialize_multisig::Token2022InitializeMultisigExtension,
+            initialize_token_account::Token2022InitializeAccountExtension,
+            memo_transfer::{MemoStatus, Token2022MemoTransferExtension},
+        },
+        suite::{
+            core::{extension::get_account_data, App},
+            types::{AppUser, PinPubkey, Target, TestResult},
+        },
+    },
+    pretty_assertions::assert_eq,
+    solana_signer::Signer,
+    spl_token_2022_interface::extension::ExtensionType,
+};
+
+//// chore: maybe add tests to check transfer behavior across different MemoStatuses;
+//// like make sure transfer fails when memo is enabled but the instruction doesn’t include one.
+//// not really necessary though — fine to skip,  since memo extension data validation (data[165..171]) is enough.
+#[test]
+fn enable_memo_transfer_with_eoa() -> TestResult<()> {
+    let mut app = App::new(false);
+
+    let (_, mint) = app.token2022_try_create_and_try_initialize_mint(Target::Spl)?;
+
+    let (_, token_account_keypair) = app.token_2022_try_create_token_account(
+        AppUser::Admin,
+        None,
+        Some(&[ExtensionType::MemoTransfer]),
+    )?;
+    let token_account = token_account_keypair.pubkey().to_bytes();
+    let alice = AppUser::Alice.pubkey();
+
+    app.token_2022_try_initialize_token_account(
+        Target::Spl,
+        AppUser::Admin,
+        &token_account,
+        &mint,
+        &alice,
+    )?;
+
+    let mut token_account_raw_data = get_account_data(&app, &token_account)?;
+
+    // assertion
+    assert_eq!(
+        MemoStatus::check_memo_status(&token_account_raw_data[165..171]),
+        MemoStatus::Initialized
+    );
+
+    // Enable Memo
+    app.token_2022_try_enable_memo_transfer(Target::Spl, &token_account, &alice, AppUser::Alice)?;
+    token_account_raw_data = get_account_data(&app, &token_account)?;
+
+    // assertion
+    assert_eq!(
+        MemoStatus::check_memo_status(&token_account_raw_data[165..171]),
+        MemoStatus::Enabled
+    );
+
+    Ok(())
+}
+
+#[test]
+fn enable_memo_transfer_with_multisig() -> TestResult<()> {
+    let mut app = App::new(false);
+    let (_, mint) = app.token2022_try_create_and_try_initialize_mint(Target::Spl)?;
+
+    // create a multisig authority with 3 signers, requiring 2 signatures
+    let signer1 = AppUser::Admin;
+    let signer2 = AppUser::Alice;
+    let signer3 = AppUser::Bob;
+    let required_signers: u8 = 2;
+
+    let (_, multisig_kp) = app.token_2022_try_create_multisig(AppUser::Admin, None)?;
+    let multisig_pubkey: &[u8; 32] = &multisig_kp.pubkey().to_bytes().into();
+    app.token_2022_try_initialize_multisig(
+        Target::Spl,
+        AppUser::Admin,
+        multisig_pubkey,
+        required_signers,
+        &[signer1.pubkey(), signer2.pubkey(), signer3.pubkey()],
+    )?;
+
+    let (_, token_account_keypair) = app.token_2022_try_create_token_account(
+        AppUser::Admin,
+        None,
+        Some(&[ExtensionType::MemoTransfer]),
+    )?;
+    let token_account = token_account_keypair.pubkey().to_bytes();
+
+    app.token_2022_try_initialize_token_account(
+        Target::Spl,
+        AppUser::Admin,
+        &token_account,
+        &mint,
+        &multisig_pubkey,
+    )?;
+
+    app.token_2022_try_enable_memo_transfer_multisig(
+        Target::Spl,
+        &token_account,
+        &multisig_pubkey,
+        &[signer1, signer2],
+    )?;
+
+    let token_account_raw_data = get_account_data(&app, &token_account)?;
+    let memo_data_slice = &token_account_raw_data[165..171];
+
+    assert_eq!(
+        MemoStatus::check_memo_status(memo_data_slice),
+        MemoStatus::Enabled
+    );
+
+    Ok(())
+}
+
+#[test]
+fn disable_memo_transfer_with_eoa() -> TestResult<()> {
+    let mut app = App::new(false);
+
+    let (_, mint) = app.token2022_try_create_and_try_initialize_mint(Target::Spl)?;
+
+    let (_, token_account_keypair) = app.token_2022_try_create_token_account(
+        AppUser::Admin,
+        None,
+        Some(&[ExtensionType::MemoTransfer]),
+    )?;
+    let token_account = token_account_keypair.pubkey().to_bytes();
+    let alice = AppUser::Alice.pubkey();
+
+    app.token_2022_try_initialize_token_account(
+        Target::Spl,
+        AppUser::Admin,
+        &token_account,
+        &mint,
+        &alice,
+    )?;
+
+    app.token_2022_try_disable_memo_transfer(Target::Spl, &token_account, &alice, AppUser::Alice)?;
+
+    let token_account_raw_data = get_account_data(&app, &token_account)?;
+    let memo_data_slice = &token_account_raw_data[165..171];
+
+    // assertion
+    assert_eq!(
+        MemoStatus::check_memo_status(memo_data_slice),
+        MemoStatus::Disabled
+    );
+
+    Ok(())
+}
+
+#[test]
+fn disable_memo_transfer_with_multisig() -> TestResult<()> {
+    let mut app = App::new(false);
+    let (_, mint) = app.token2022_try_create_and_try_initialize_mint(Target::Spl)?;
+
+    // create a multisig authority with 3 signers, requiring 2 signatures
+    let signer1 = AppUser::Admin;
+    let signer2 = AppUser::Alice;
+    let signer3 = AppUser::Bob;
+    let required_signers: u8 = 2;
+
+    let (_, multisig_kp) = app.token_2022_try_create_multisig(AppUser::Admin, None)?;
+    let multisig_pubkey: &[u8; 32] = &multisig_kp.pubkey().to_bytes().into();
+    app.token_2022_try_initialize_multisig(
+        Target::Spl,
+        AppUser::Admin,
+        multisig_pubkey,
+        required_signers,
+        &[signer1.pubkey(), signer2.pubkey(), signer3.pubkey()],
+    )?;
+
+    let (_, token_account_keypair) = app.token_2022_try_create_token_account(
+        AppUser::Admin,
+        None,
+        Some(&[ExtensionType::MemoTransfer]),
+    )?;
+    let token_account = token_account_keypair.pubkey().to_bytes();
+
+    app.token_2022_try_initialize_token_account(
+        Target::Spl,
+        AppUser::Admin,
+        &token_account,
+        &mint,
+        &multisig_pubkey,
+    )?;
+
+    app.token_2022_try_disable_memo_transfer_multisig(
+        Target::Spl,
+        &token_account,
+        &multisig_pubkey,
+        &[signer1, signer2],
+    )?;
+
+    let token_account_raw_data = get_account_data(&app, &token_account)?;
+    let memo_data_slice = &token_account_raw_data[165..171];
+
+    // assertion
+    assert_eq!(
+        MemoStatus::check_memo_status(memo_data_slice),
+        MemoStatus::Disabled
+    );
+
+    Ok(())
+}
+
+//// TODO : Add Target::Proxy Tests :
+//// proxy_enable_memo_transfer_with_eoa
+//// proxy_enable_memo_transfer_with_multisig
+//// proxy_disable_memo_transfer_with_eoa
+//// proxy_disable_memo_transfer_with_multisig

--- a/programs/token-2022/src/extension/consts.rs
+++ b/programs/token-2022/src/extension/consts.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
 pub enum ExtensionDiscriminator {
+    MemoTransfer = 30,
     PermanentDelegate = 35,
     GroupPointer = 40,
     GroupMemberPointer = 41,

--- a/programs/token-2022/src/extension/memo_transfer/instructions/disable.rs
+++ b/programs/token-2022/src/extension/memo_transfer/instructions/disable.rs
@@ -1,0 +1,144 @@
+use {
+    crate::{
+        extension::{
+            consts::ExtensionDiscriminator,
+            memo_transfer::state::{
+                offset_memo_transfer as OFFSET, InstructionDiscriminatorMemoTransfer,
+            },
+        },
+        instructions::MAX_MULTISIG_SIGNERS,
+    },
+    core::{mem::MaybeUninit, slice},
+    pinocchio::{
+        account_info::AccountInfo,
+        cpi::invoke_signed_with_bounds,
+        instruction::{AccountMeta, Instruction, Signer},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        ProgramResult,
+    },
+};
+
+/// Disable the MemoTransfer extension on a token account.
+///
+/// Expected accounts:
+///
+/// **Single authority**
+/// 0. `[writable]` The token account to disable memo transfer.
+/// 1. `[signer]` The owner of the token account.
+///
+/// **Multisignature authority**
+/// 0. `[writable]` The token account to disable memo transfer.
+/// 1. `[readonly]` The multisig account that owns the token account.
+/// 2. `[signer]` M signer accounts (as required by the multisig).
+pub struct Disable<'a> {
+    /// The token account to disable with the MemoTransfer extension.
+    pub token_account: &'a AccountInfo,
+    /// The owner of the token account (single or multisig).
+    pub authority: &'a AccountInfo,
+    /// Signer accounts if the authority is a multisig.
+    pub signers: &'a [AccountInfo],
+    /// Token program (Token-2022).
+    pub token_program: &'a Pubkey,
+}
+
+impl Disable<'_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        let &Self {
+            token_account,
+            authority,
+            signers: multisig_accounts,
+            token_program,
+            ..
+        } = self;
+
+        if multisig_accounts.len() > MAX_MULTISIG_SIGNERS {
+            Err(ProgramError::InvalidArgument)?;
+        }
+
+        const UNINIT_ACCOUNT_METAS: MaybeUninit<AccountMeta> = MaybeUninit::<AccountMeta>::uninit();
+        let mut account_metas = [UNINIT_ACCOUNT_METAS; 2 + MAX_MULTISIG_SIGNERS];
+
+        unsafe {
+            // SAFETY:
+            // - `account_metas` is sized to 2 + MAX_MULTISIG_SIGNERS
+
+            // - Index 0 is always present (TokenAccount)
+            account_metas
+                .get_unchecked_mut(0)
+                .write(AccountMeta::writable(token_account.key()));
+
+            // - Index 1 is always present (Authority)
+            if multisig_accounts.is_empty() {
+                account_metas
+                    .get_unchecked_mut(1)
+                    .write(AccountMeta::readonly_signer(authority.key()));
+            } else {
+                account_metas
+                    .get_unchecked_mut(1)
+                    .write(AccountMeta::readonly(authority.key()));
+            }
+        }
+
+        // If present, write multisig signer metas into account_metas[2..]
+        for (account_meta, signer) in account_metas[2..].iter_mut().zip(multisig_accounts.iter()) {
+            account_meta.write(AccountMeta::readonly_signer(signer.key()));
+        }
+
+        // build instruction
+        let mut buffer = [0u8; OFFSET::END as usize];
+        let data = disable_instruction_data(&mut buffer);
+
+        let num_accounts = 2 + multisig_accounts.len();
+
+        let instruction = Instruction {
+            program_id: token_program,
+            data: data,
+            accounts: unsafe { slice::from_raw_parts(account_metas.as_ptr() as _, num_accounts) },
+        };
+
+        // build invoke_signed compatible AccountInfo array
+        const UNINIT_ACCOUNT_INFOS: MaybeUninit<&AccountInfo> =
+            MaybeUninit::<&AccountInfo>::uninit(); // dev: store references to AccountInfo to avoid moving ownership
+        let mut account_infos = [UNINIT_ACCOUNT_INFOS; 2 + MAX_MULTISIG_SIGNERS];
+
+        unsafe {
+            // SAFETY:
+            // - `account_infos` is sized to 2 + MAX_MULTISIG_SIGNERS
+            // - Index 0 is always present
+            account_infos.get_unchecked_mut(0).write(token_account);
+            // - Index 1 is always present
+            account_infos.get_unchecked_mut(1).write(authority);
+        }
+
+        // If present, write multisig accounts
+        for (account_info, signer) in account_infos[2..].iter_mut().zip(multisig_accounts.iter()) {
+            account_info.write(signer);
+        }
+
+        // dev: `invoke_signed_with_bounds` used because `invoke_signed` would revert; slice length is known at compile-time, enabling safe, optimized calls.
+        invoke_signed_with_bounds::<{ 2 + MAX_MULTISIG_SIGNERS }>(
+            &instruction,
+            unsafe { slice::from_raw_parts(account_infos.as_ptr() as _, num_accounts) },
+            signers,
+        )
+    }
+}
+
+pub fn disable_instruction_data<'a>(buffer: &'a mut [u8]) -> &'a [u8] {
+    let offset = OFFSET::START as usize;
+
+    // Encode discriminators (MemoTransfer + Disable)
+    buffer[..offset].copy_from_slice(&[
+        ExtensionDiscriminator::MemoTransfer as u8,
+        InstructionDiscriminatorMemoTransfer::Disable as u8,
+    ]);
+
+    buffer
+}

--- a/programs/token-2022/src/extension/memo_transfer/instructions/enable.rs
+++ b/programs/token-2022/src/extension/memo_transfer/instructions/enable.rs
@@ -1,0 +1,144 @@
+use {
+    crate::{
+        extension::{
+            consts::ExtensionDiscriminator,
+            memo_transfer::state::{
+                offset_memo_transfer as OFFSET, InstructionDiscriminatorMemoTransfer,
+            },
+        },
+        instructions::MAX_MULTISIG_SIGNERS,
+    },
+    core::{mem::MaybeUninit, slice},
+    pinocchio::{
+        account_info::AccountInfo,
+        cpi::invoke_signed_with_bounds,
+        instruction::{AccountMeta, Instruction, Signer},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        ProgramResult,
+    },
+};
+
+/// Enable the MemoTransfer extension on a token account.
+///
+/// Expected accounts:
+///
+/// **Single authority**
+/// 0. `[writable]` The token account to enable memo transfer.
+/// 1. `[signer]` The owner of the token account.
+///
+/// **Multisignature authority**
+/// 0. `[writable]` The token account to enable memo transfer.
+/// 1. `[readonly]` The multisig account that owns the token account.
+/// 2. `[signer]` M signer accounts (as required by the multisig).
+pub struct Enable<'a> {
+    /// The token account to enable with the MemoTransfer extension.
+    pub token_account: &'a AccountInfo,
+    /// The owner of the token account (single or multisig).
+    pub authority: &'a AccountInfo,
+    /// Signer accounts if the authority is a multisig.
+    pub signers: &'a [AccountInfo],
+    /// Token program (Token-2022).
+    pub token_program: &'a Pubkey,
+}
+
+impl Enable<'_> {
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        let &Self {
+            token_account,
+            authority,
+            signers: multisig_accounts,
+            token_program,
+            ..
+        } = self;
+
+        if multisig_accounts.len() > MAX_MULTISIG_SIGNERS {
+            Err(ProgramError::InvalidArgument)?;
+        }
+
+        const UNINIT_ACCOUNT_METAS: MaybeUninit<AccountMeta> = MaybeUninit::<AccountMeta>::uninit();
+        let mut account_metas = [UNINIT_ACCOUNT_METAS; 2 + MAX_MULTISIG_SIGNERS];
+
+        unsafe {
+            // SAFETY:
+            // - `account_metas` is sized to 2 + MAX_MULTISIG_SIGNERS
+
+            // - Index 0 is always present (TokenAccount)
+            account_metas
+                .get_unchecked_mut(0)
+                .write(AccountMeta::writable(token_account.key()));
+
+            // - Index 1 is always present (Authority)
+            if multisig_accounts.is_empty() {
+                account_metas
+                    .get_unchecked_mut(1)
+                    .write(AccountMeta::readonly_signer(authority.key()));
+            } else {
+                account_metas
+                    .get_unchecked_mut(1)
+                    .write(AccountMeta::readonly(authority.key()));
+            }
+        }
+
+        // If present, write multisig signer metas into account_metas[2..]
+        for (account_meta, signer) in account_metas[2..].iter_mut().zip(multisig_accounts.iter()) {
+            account_meta.write(AccountMeta::readonly_signer(signer.key()));
+        }
+
+        // build instruction
+        let mut buffer = [0u8; OFFSET::END as usize];
+        let data = enable_instruction_data(&mut buffer);
+
+        let num_accounts = 2 + multisig_accounts.len();
+
+        let instruction = Instruction {
+            program_id: token_program,
+            data: data,
+            accounts: unsafe { slice::from_raw_parts(account_metas.as_ptr() as _, num_accounts) },
+        };
+
+        // build invoke_signed compatible AccountInfo array
+        const UNINIT_ACCOUNT_INFOS: MaybeUninit<&AccountInfo> =
+            MaybeUninit::<&AccountInfo>::uninit(); // dev: store references to AccountInfo to avoid moving ownership
+        let mut account_infos = [UNINIT_ACCOUNT_INFOS; 2 + MAX_MULTISIG_SIGNERS];
+
+        unsafe {
+            // SAFETY:
+            // - `account_infos` is sized to 2 + MAX_MULTISIG_SIGNERS
+            // - Index 0 is always present
+            account_infos.get_unchecked_mut(0).write(token_account);
+            // - Index 1 is always present
+            account_infos.get_unchecked_mut(1).write(authority);
+        }
+
+        // If present, write multisig accounts
+        for (account_info, signer) in account_infos[2..].iter_mut().zip(multisig_accounts.iter()) {
+            account_info.write(signer);
+        }
+
+        // dev: `invoke_signed_with_bounds` used because `invoke_signed` would revert; slice length is known at compile-time, enabling safe, optimized calls.
+        invoke_signed_with_bounds::<{ 2 + MAX_MULTISIG_SIGNERS }>(
+            &instruction,
+            unsafe { slice::from_raw_parts(account_infos.as_ptr() as _, num_accounts) },
+            signers,
+        )
+    }
+}
+
+pub fn enable_instruction_data<'a>(buffer: &'a mut [u8]) -> &'a [u8] {
+    let offset = OFFSET::START as usize;
+
+    // Encode discriminators (MemoTransfer + Enable)
+    buffer[..offset].copy_from_slice(&[
+        ExtensionDiscriminator::MemoTransfer as u8,
+        InstructionDiscriminatorMemoTransfer::Enable as u8,
+    ]);
+
+    buffer
+}

--- a/programs/token-2022/src/extension/memo_transfer/instructions/mod.rs
+++ b/programs/token-2022/src/extension/memo_transfer/instructions/mod.rs
@@ -1,0 +1,4 @@
+mod disable;
+mod enable;
+
+pub use {disable::*, enable::*};

--- a/programs/token-2022/src/extension/memo_transfer/mod.rs
+++ b/programs/token-2022/src/extension/memo_transfer/mod.rs
@@ -1,0 +1,4 @@
+pub mod instructions;
+pub mod state;
+
+pub use {instructions::*, state::*};

--- a/programs/token-2022/src/extension/memo_transfer/state.rs
+++ b/programs/token-2022/src/extension/memo_transfer/state.rs
@@ -1,0 +1,142 @@
+use {
+    crate::ID,
+    pinocchio::{
+        account_info::{AccountInfo, Ref},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+    },
+};
+
+#[repr(u8)]
+pub enum InstructionDiscriminatorMemoTransfer {
+    Enable = 0,
+    Disable = 1,
+}
+
+/// Instruction data layout:
+/// - [0]                        : Extension discriminator (1 byte)
+/// - [1]                        : Instruction discriminator (1 byte)
+/// dev: Since only the instruction discriminator is used to toggle memo transfer states
+/// and no additional parameters are required, `START == END`.
+pub mod offset_memo_transfer {
+    pub const START: u8 = 2;
+    pub const END: u8 = START;
+}
+
+/// Models onchain `MemoTransfer` state.
+/// Mirrors SPL Token-2022:
+/// `pub struct MemoTransfer { pub require_incoming_transfer_memos: PodBool }`
+#[repr(C)]
+pub struct MemoTransfer {
+    /// Indicates whether incoming transfers must include a memo.
+    pub require_incoming_transfer_memos: bool,
+}
+
+impl MemoTransfer {
+    /// The length of the token_account with `MemoTransfer` extension data
+    const LEN: u8 = 171;
+
+    /// The byte index where the `require_incoming_transfer_memos` flag is stored
+    /// within a Token-2022 account initialized with the `MemoTransfer` extension.
+    const REQUIRE_MEMO_FLAG_INDEX: u8 = 170;
+
+    /// Init with given memo requirement flag.
+    #[inline]
+    pub fn new(require_memo: bool) -> Self {
+        Self {
+            require_incoming_transfer_memos: require_memo,
+        }
+    }
+
+    /// Return a `MemoTransfer` from the given account info.
+    ///
+    /// This method performs owner and length validation on `AccountInfo`, safe borrowing
+    /// the account data.
+    #[inline]
+    pub fn from_account_info(
+        account_info: &AccountInfo,
+    ) -> Result<Ref<MemoTransfer>, ProgramError> {
+        // Check data length first
+        if account_info.data_len() < Self::LEN as usize {
+            Err(ProgramError::InvalidAccountData)?;
+        }
+
+        // Check owner
+        if account_info.owner() != &ID {
+            Err(ProgramError::InvalidAccountOwner)?;
+        }
+
+        // Safely borrow and map the data
+        let data_ref = account_info
+            .try_borrow_data()
+            .map_err(|_| ProgramError::AccountBorrowFailed)?;
+
+        Ok(Ref::map(data_ref, |data| unsafe {
+            Self::from_bytes_unchecked(data)
+        }))
+    }
+
+    /// Return a `MemoTransfer` from the given account info.
+    ///
+    /// This method performs owner and length validation on `AccountInfo`, but does not
+    /// perform the borrow check.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that it is safe to borrow the account data (e.g., there are
+    /// no mutable borrows of the account data).
+    #[inline]
+    pub unsafe fn from_account_info_unchecked(
+        account_info: &AccountInfo,
+    ) -> Result<&Self, ProgramError> {
+        // Check data length first
+        if account_info.data_len() < Self::LEN as usize {
+            Err(ProgramError::InvalidAccountData)?;
+        }
+
+        // Check owner
+        if account_info.owner() != &ID {
+            Err(ProgramError::InvalidAccountOwner)?;
+        }
+
+        // Get unchecked borrow and convert
+        let data = account_info.borrow_data_unchecked();
+        Ok(Self::from_bytes_unchecked(data))
+    }
+
+    /// Return a `MemoTransfer` from the given bytes.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    /// 1. `bytes` contains at least `LEN` bytes
+    /// 2. `bytes` contains a valid representation of `MemoTransfer`
+    /// 3. The data is properly aligned (though MemoTransfer has alignment of 1)
+    /// 4. The bytes represent valid flag values and pubkey data
+    #[inline(always)]
+    pub unsafe fn from_bytes_unchecked(bytes: &[u8]) -> &Self {
+        &*(bytes[Self::REQUIRE_MEMO_FLAG_INDEX as usize..].as_ptr() as *const MemoTransfer)
+    }
+
+    /// Safe version of from_bytes that performs validation
+    #[inline]
+    pub fn from_bytes(bytes: &[u8]) -> Result<&Self, ProgramError> {
+        if bytes.len() < Self::LEN as usize {
+            Err(ProgramError::InvalidAccountData)?;
+        }
+
+        Ok(unsafe { Self::from_bytes_unchecked(bytes) })
+    }
+
+    /// Returns true if memo transfers are enabled.
+    #[inline(always)]
+    pub fn is_enabled(&self) -> bool {
+        self.require_incoming_transfer_memos
+    }
+
+    /// Returns true if memo transfers are disabled.
+    #[inline(always)]
+    pub fn is_disabled(&self) -> bool {
+        !self.require_incoming_transfer_memos
+    }
+}

--- a/programs/token-2022/src/extension/mod.rs
+++ b/programs/token-2022/src/extension/mod.rs
@@ -1,5 +1,6 @@
 pub mod consts;
 pub mod group_member_pointer;
 pub mod group_pointer;
+pub mod memo_transfer;
 pub mod permanent_delegate;
 pub mod token_group;


### PR DESCRIPTION
**Key Updates:**

- added full `memo transfer` extension with proxy support + tests for both `spl` and `proxy`
- added a token account test helper with verified passing tests on both targets `(Spl and Proxy)`, along with corresponding proxy handling logic.

**Note:**
- All tests are passing
- PR is ready for the merge
