### PR TITLE
Memo transfer: inline and privitize instruction data builders and ExtentionDiscriminator enum

### DIFF
--- a/programs/token-2022/src/instructions/extensions/memo_transfer/instructions/disable.rs
+++ b/programs/token-2022/src/instructions/extensions/memo_transfer/instructions/disable.rs
@@ -121,7 +121,8 @@ impl Disable<'_, '_> {
     }
 }
 
-pub fn disable_instruction_data<'a>(buffer: &'a mut [u8]) -> &'a [u8] {
+#[inline(always)]
+fn disable_instruction_data<'a>(buffer: &'a mut [u8]) -> &'a [u8] {
     let offset = OFFSET::START as usize;
 
     // Encode discriminators (MemoTransfer + Disable)

--- a/programs/token-2022/src/instructions/extensions/memo_transfer/instructions/enable.rs
+++ b/programs/token-2022/src/instructions/extensions/memo_transfer/instructions/enable.rs
@@ -121,7 +121,8 @@ impl Enable<'_, '_> {
     }
 }
 
-pub fn enable_instruction_data<'a>(buffer: &'a mut [u8]) -> &'a [u8] {
+#[inline(always)]
+fn enable_instruction_data<'a>(buffer: &'a mut [u8]) -> &'a [u8] {
     let offset = OFFSET::START as usize;
 
     // Encode discriminators (MemoTransfer + Enable)

--- a/programs/token-2022/src/instructions/extensions/mod.rs
+++ b/programs/token-2022/src/instructions/extensions/mod.rs
@@ -1,7 +1,7 @@
 pub mod memo_transfer;
 
 #[repr(u8)]
-pub enum ExtensionDiscriminator {
+pub(crate) enum ExtensionDiscriminator {
     /// Default Account State extension
     DefaultAccountState = 28,
     /// Memo Transfer extension


### PR DESCRIPTION
**Key Updates:**

- Made ExtentionDiscriminator enum  private to the crate
- Inlined and converted instruction data builders in memo transfer to private functions