### PR TITLE
feat: added pausable extension to instructions

### DIFF
--- a/programs/token-2022/src/instructions/extensions/mod.rs
+++ b/programs/token-2022/src/instructions/extensions/mod.rs
@@ -1,7 +1,10 @@
 pub mod memo_transfer;
+pub mod pausable;
 
 #[repr(u8)]
 #[non_exhaustive]
 pub enum ExtensionDiscriminator {
     MemoTransfer = 30,
+    Pausable = 44,
+    CpiGuard = 34,
 }

--- a/programs/token-2022/src/instructions/extensions/pausable/initialize.rs
+++ b/programs/token-2022/src/instructions/extensions/pausable/initialize.rs
@@ -1,0 +1,134 @@
+use {
+    crate::{instructions::extensions::ExtensionDiscriminator, instructions::MAX_MULTISIG_SIGNERS},
+    core::{mem::MaybeUninit, slice},
+    solana_account_view::AccountView,
+    solana_address::Address,
+    solana_instruction_view::{
+        cpi::{invoke_signed_with_bounds, Signer},
+        InstructionAccount, InstructionView,
+    },
+    solana_program_error::{ProgramError, ProgramResult},
+};
+
+/// Enable the Pausable extension on a token account.
+///
+/// Expected accounts:
+///
+/// **Single authority**
+///
+/// 0. `[writable]` The token account to initialize pausable token.
+/// 1. `[signer]` The owner of the token account.
+///
+/// **Multisignature authority**
+///
+/// 0. `[writable]` The token account to initialize pausable token.
+/// 1. `[readonly]` The multisig account that owns the token account.
+/// 2. `[signer]` M signer accounts (as required by the multisig).
+pub struct InitializePausable<'a, 'b, 'c> {
+    /// The token account to enable with the Memo-Transfer extension.
+    pub token_account: &'a AccountView,
+    /// The owner of the token account (single or multisig).
+    pub authority: &'a AccountView,
+    /// Signer accounts if the authority is a multisig.
+    pub signers: &'c [&'a AccountView],
+    /// Token program (Token-2022).
+    pub token_program: &'b Address,
+}
+
+impl InitializePausable<'_, '_, '_> {
+    pub const DISCRIMINATOR: u8 = 0;
+
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        let &Self {
+            token_account,
+            authority,
+            signers: multisig_accounts,
+            token_program,
+            ..
+        } = self;
+
+        if multisig_accounts.len() > MAX_MULTISIG_SIGNERS {
+            return Err(ProgramError::InvalidArgument);
+        }
+
+        // creates an array of uninitialized InstructionAccount with 2 + MAX_MULTISIG_SIGNERS
+        // i.e. [token_account + authority](2) + signers(max_multisig_signers)
+        const UNINIT_INSTRUCTION_ACCOUNTS: MaybeUninit<InstructionAccount> =
+            MaybeUninit::<InstructionAccount>::uninit();
+        let mut instruction_accounts = [UNINIT_INSTRUCTION_ACCOUNTS; 2 + MAX_MULTISIG_SIGNERS];
+
+        // SAFETY:
+        // - `instruction_accounts` is sized to 2 + MAX_MULTISIG_SIGNERS
+        unsafe {
+            // - Index 0 is always present (TokenAccount)
+            instruction_accounts
+                .get_unchecked_mut(0)
+                .write(InstructionAccount::writable(token_account.address()));
+
+            // - Index 1 is always present (Authority)
+            instruction_accounts
+                .get_unchecked_mut(1)
+                .write(InstructionAccount::new(
+                    authority.address(),
+                    false,
+                    multisig_accounts.is_empty(),
+                ));
+        }
+
+        // add the multisig if they exist for each signer account
+        // creates a tuple of (account, signer) for each multisig i.e from index 2
+        for (instruction_account, signer) in instruction_accounts[2..]
+            .iter_mut()
+            .zip(multisig_accounts.iter())
+        {
+            instruction_account.write(InstructionAccount::readonly_signer(signer.address()));
+        }
+
+        // build instruction data for Pausable
+        let data = &[ExtensionDiscriminator::Pausable as u8, Self::DISCRIMINATOR];
+
+        let num_accounts = 2 + multisig_accounts.len();
+
+        // build instruction for Pausable
+        let instruction = InstructionView {
+            program_id: token_program,
+            data,
+            accounts: unsafe {
+                // create a slice &[] by providing the pointer to that data and the length of the data
+                slice::from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts)
+            },
+        };
+
+        // Account view array
+        const UNINIT_ACCOUNT_VIEWS: MaybeUninit<&AccountView> = MaybeUninit::uninit();
+        let mut account_views = [UNINIT_ACCOUNT_VIEWS; 2 + MAX_MULTISIG_SIGNERS];
+
+        // SAFETY:
+        // - `account_views` is sized to 2 + MAX_MULTISIG_SIGNERS
+        unsafe {
+            // - Index 0 is always present
+            account_views.get_unchecked_mut(0).write(token_account);
+            // - Index 1 is always present
+            account_views.get_unchecked_mut(1).write(authority);
+        }
+
+        // Fill signer accounts
+        for (account_view, signer) in account_views[2..].iter_mut().zip(multisig_accounts.iter()) {
+            account_view.write(signer);
+        }
+
+        invoke_signed_with_bounds::<{ 2 + MAX_MULTISIG_SIGNERS }>(
+            &instruction,
+            unsafe {
+                slice::from_raw_parts(account_views.as_ptr() as *const &AccountView, num_accounts)
+            },
+            signers,
+        )
+    }
+}

--- a/programs/token-2022/src/instructions/extensions/pausable/mod.rs
+++ b/programs/token-2022/src/instructions/extensions/pausable/mod.rs
@@ -1,0 +1,7 @@
+pub mod initialize;
+pub mod pause;
+pub mod resume;
+
+pub use initialize::*;
+pub use pause::*;
+pub use resume::*;

--- a/programs/token-2022/src/instructions/extensions/pausable/pause.rs
+++ b/programs/token-2022/src/instructions/extensions/pausable/pause.rs
@@ -1,0 +1,134 @@
+use {
+    crate::{instructions::extensions::ExtensionDiscriminator, instructions::MAX_MULTISIG_SIGNERS},
+    core::{mem::MaybeUninit, slice},
+    solana_account_view::AccountView,
+    solana_address::Address,
+    solana_instruction_view::{
+        cpi::{invoke_signed_with_bounds, Signer},
+        InstructionAccount, InstructionView,
+    },
+    solana_program_error::{ProgramError, ProgramResult},
+};
+
+/// Pause a token account.
+///
+/// Expected accounts:
+///
+/// **Single authority**
+///
+/// 0. `[writable]` The token account to pause.
+/// 1. `[signer]` The pause authority of the token account.
+///
+/// **Multisignature authority**
+///
+/// 0. `[writable]` The token account to pause.
+/// 1. `[readonly]` The multisig account that has pause authority.
+/// 2. `[signer]` M signer accounts (as required by the multisig).
+pub struct Pause<'a, 'b, 'c> {
+    /// The token account to pause.
+    pub token_account: &'a AccountView,
+    /// The pause authority of the token account.
+    pub authority: &'a AccountView,
+    /// Signer accounts if the authority is a multisig.
+    pub signers: &'c [&'a AccountView],
+    /// Token program (Token-2022).
+    pub token_program: &'b Address,
+}
+
+impl Pause<'_, '_, '_> {
+    pub const DISCRIMINATOR: u8 = 1;
+
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        let &Self {
+            token_account,
+            authority,
+            signers: multisig_accounts,
+            token_program,
+            ..
+        } = self;
+
+        if multisig_accounts.len() > MAX_MULTISIG_SIGNERS {
+            return Err(ProgramError::InvalidArgument);
+        }
+
+        // creates an array of uninitialized InstructionAccount with 2 + MAX_MULTISIG_SIGNERS
+        // i.e. [token_account + authority](2) + signers(max_multisig_signers)
+        const UNINIT_INSTRUCTION_ACCOUNTS: MaybeUninit<InstructionAccount> =
+            MaybeUninit::<InstructionAccount>::uninit();
+        let mut instruction_accounts = [UNINIT_INSTRUCTION_ACCOUNTS; 2 + MAX_MULTISIG_SIGNERS];
+
+        // SAFETY:
+        // - `instruction_accounts` is sized to 2 + MAX_MULTISIG_SIGNERS
+        unsafe {
+            // - Index 0 is always present (TokenAccount)
+            instruction_accounts
+                .get_unchecked_mut(0)
+                .write(InstructionAccount::writable(token_account.address()));
+
+            // - Index 1 is always present (Authority)
+            instruction_accounts
+                .get_unchecked_mut(1)
+                .write(InstructionAccount::new(
+                    authority.address(),
+                    false,
+                    multisig_accounts.is_empty(),
+                ));
+        }
+
+        // add the multisig if they exist for each signer account
+        // creates a tuple of (account, signer) for each multisig i.e from index 2
+        for (instruction_account, signer) in instruction_accounts[2..]
+            .iter_mut()
+            .zip(multisig_accounts.iter())
+        {
+            instruction_account.write(InstructionAccount::readonly_signer(signer.address()));
+        }
+
+        // build instruction data for Pausable
+        let data = &[ExtensionDiscriminator::Pausable as u8, Self::DISCRIMINATOR];
+
+        let num_accounts = 2 + multisig_accounts.len();
+
+        // build instruction for Pausable
+        let instruction = InstructionView {
+            program_id: token_program,
+            data,
+            accounts: unsafe {
+                // create a slice &[] by providing the pointer to that data and the length of the data
+                slice::from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts)
+            },
+        };
+
+        // Account view array
+        const UNINIT_ACCOUNT_VIEWS: MaybeUninit<&AccountView> = MaybeUninit::uninit();
+        let mut account_views = [UNINIT_ACCOUNT_VIEWS; 2 + MAX_MULTISIG_SIGNERS];
+
+        // SAFETY:
+        // - `account_views` is sized to 2 + MAX_MULTISIG_SIGNERS
+        unsafe {
+            // - Index 0 is always present
+            account_views.get_unchecked_mut(0).write(token_account);
+            // - Index 1 is always present
+            account_views.get_unchecked_mut(1).write(authority);
+        }
+
+        // Fill signer accounts
+        for (account_view, signer) in account_views[2..].iter_mut().zip(multisig_accounts.iter()) {
+            account_view.write(signer);
+        }
+
+        invoke_signed_with_bounds::<{ 2 + MAX_MULTISIG_SIGNERS }>(
+            &instruction,
+            unsafe {
+                slice::from_raw_parts(account_views.as_ptr() as *const &AccountView, num_accounts)
+            },
+            signers,
+        )
+    }
+}

--- a/programs/token-2022/src/instructions/extensions/pausable/resume.rs
+++ b/programs/token-2022/src/instructions/extensions/pausable/resume.rs
@@ -1,0 +1,132 @@
+use {
+    crate::{instructions::extensions::ExtensionDiscriminator, instructions::MAX_MULTISIG_SIGNERS},
+    core::{mem::MaybeUninit, slice},
+    solana_account_view::AccountView,
+    solana_address::Address,
+    solana_instruction_view::{
+        cpi::{invoke_signed_with_bounds, Signer},
+        InstructionAccount, InstructionView,
+    },
+    solana_program_error::{ProgramError, ProgramResult},
+};
+
+/// Resume (unpause) a token account.
+///
+/// Expected accounts:
+///
+/// **Single authority**
+/// 0. `[writable]` The token account to resume.
+/// 1. `[signer]` The pause authority of the token account.
+///
+/// **Multisignature authority**
+/// 0. `[writable]` The token account to resume.
+/// 1. `[readonly]` The multisig account that has pause authority.
+/// 2. `[signer]` M signer accounts (as required by the multisig).
+pub struct Resume<'a, 'b, 'c> {
+    /// The token account to resume.
+    pub token_account: &'a AccountView,
+    /// The pause authority of the token account.
+    pub authority: &'a AccountView,
+    /// Signer accounts if the authority is a multisig.
+    pub signers: &'c [&'a AccountView],
+    /// Token program (Token-2022).
+    pub token_program: &'b Address,
+}
+
+impl Resume<'_, '_, '_> {
+    pub const DISCRIMINATOR: u8 = 2;
+
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        let &Self {
+            token_account,
+            authority,
+            signers: multisig_accounts,
+            token_program,
+            ..
+        } = self;
+
+        if multisig_accounts.len() > MAX_MULTISIG_SIGNERS {
+            return Err(ProgramError::InvalidArgument);
+        }
+
+        // creates an array of uninitialized InstructionAccount with 2 + MAX_MULTISIG_SIGNERS
+        // i.e. [token_account + authority](2) + signers(max_multisig_signers)
+        const UNINIT_INSTRUCTION_ACCOUNTS: MaybeUninit<InstructionAccount> =
+            MaybeUninit::<InstructionAccount>::uninit();
+        let mut instruction_accounts = [UNINIT_INSTRUCTION_ACCOUNTS; 2 + MAX_MULTISIG_SIGNERS];
+
+        // SAFETY:
+        // - `instruction_accounts` is sized to 2 + MAX_MULTISIG_SIGNERS
+        unsafe {
+            // - Index 0 is always present (TokenAccount)
+            instruction_accounts
+                .get_unchecked_mut(0)
+                .write(InstructionAccount::writable(token_account.address()));
+
+            // - Index 1 is always present (Authority)
+            instruction_accounts
+                .get_unchecked_mut(1)
+                .write(InstructionAccount::new(
+                    authority.address(),
+                    false,
+                    multisig_accounts.is_empty(),
+                ));
+        }
+
+        // add the multisig if they exist for each signer account
+        // creates a tuple of (account, signer) for each multisig i.e from index 2
+        for (instruction_account, signer) in instruction_accounts[2..]
+            .iter_mut()
+            .zip(multisig_accounts.iter())
+        {
+            instruction_account.write(InstructionAccount::readonly_signer(signer.address()));
+        }
+
+        // build instruction data for Pausable
+        let data = &[ExtensionDiscriminator::Pausable as u8, Self::DISCRIMINATOR];
+
+        let num_accounts = 2 + multisig_accounts.len();
+
+        // build instruction for Pausable
+        let instruction = InstructionView {
+            program_id: token_program,
+            data,
+            accounts: unsafe {
+                // create a slice &[] by providing the pointer to that data and the length of the data
+                slice::from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts)
+            },
+        };
+
+        // Account view array
+        const UNINIT_ACCOUNT_VIEWS: MaybeUninit<&AccountView> = MaybeUninit::uninit();
+        let mut account_views = [UNINIT_ACCOUNT_VIEWS; 2 + MAX_MULTISIG_SIGNERS];
+
+        // SAFETY:
+        // - `account_views` is sized to 2 + MAX_MULTISIG_SIGNERS
+        unsafe {
+            // - Index 0 is always present
+            account_views.get_unchecked_mut(0).write(token_account);
+            // - Index 1 is always present
+            account_views.get_unchecked_mut(1).write(authority);
+        }
+
+        // Fill signer accounts
+        for (account_view, signer) in account_views[2..].iter_mut().zip(multisig_accounts.iter()) {
+            account_view.write(signer);
+        }
+
+        invoke_signed_with_bounds::<{ 2 + MAX_MULTISIG_SIGNERS }>(
+            &instruction,
+            unsafe {
+                slice::from_raw_parts(account_views.as_ptr() as *const &AccountView, num_accounts)
+            },
+            signers,
+        )
+    }
+}


### PR DESCRIPTION
This PR adds three instructions to the pausable extension instruction.
`InitializePausable`, `Pause`, `Resume` with discriminators `0`, `1`, and `2` respectively.

```rs
pub struct InitializePausable<'a, 'b, 'c> {
    /// The token account to enable with the Memo-Transfer extension.
    pub token_account: &'a AccountView,
    /// The owner of the token account (single or multisig).
    pub authority: &'a AccountView,
    /// Signer accounts if the authority is a multisig.
    pub signers: &'c [&'a AccountView],
    /// Token program (Token-2022).
    pub token_program: &'b Address,
}```