### PR TITLE
Inspiration cpi guard

### DIFF
--- a/programs/token-2022/src/instructions/extensions/cpi_guard/disable.rs
+++ b/programs/token-2022/src/instructions/extensions/cpi_guard/disable.rs
@@ -1,0 +1,132 @@
+use {
+    crate::{instructions::extensions::ExtensionDiscriminator, instructions::MAX_MULTISIG_SIGNERS},
+    core::{mem::MaybeUninit, slice},
+    solana_account_view::AccountView,
+    solana_address::Address,
+    solana_instruction_view::{
+        cpi::{invoke_signed_with_bounds, Signer},
+        InstructionAccount, InstructionView,
+    },
+    solana_program_error::{ProgramError, ProgramResult},
+};
+
+/// Disable the CPI Guard extension on a token account.
+///
+/// Expected accounts:
+///
+/// **Single authority**
+/// 0. `[writable]` The token account to enable cpi-guard.
+/// 1. `[signer]` The owner of the token account.
+///
+/// **Multisignature authority**
+/// 0. `[writable]` The token account to enable cpi-guard.
+/// 1. `[readonly]` The multisig account that owns the token account.
+/// 2. `[signer]` M signer accounts (as required by the multisig).
+pub struct DisableCpiGuard<'a, 'b, 'c> {
+    /// The token account to enable with the Memo-Transfer extension.
+    pub token_account: &'a AccountView,
+    /// The owner of the token account (single or multisig).
+    pub authority: &'a AccountView,
+    /// Signer accounts if the authority is a multisig.
+    pub signers: &'c [&'a AccountView],
+    /// Token program (Token-2022).
+    pub token_program: &'b Address,
+}
+
+impl DisableCpiGuard<'_, '_, '_> {
+    pub const DISCRIMINATOR: u8 = 1;
+
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        let &Self {
+            token_account,
+            authority,
+            signers: multisig_accounts,
+            token_program,
+            ..
+        } = self;
+
+        if multisig_accounts.len() > MAX_MULTISIG_SIGNERS {
+            return Err(ProgramError::InvalidArgument);
+        }
+
+        // creates an array of uninitialized InstructionAccount with 2 + MAX_MULTISIG_SIGNERS
+        // i.e. [token_account + authority](2) + signers(max_multisig_signers)
+        const UNINIT_INSTRUCTION_ACCOUNTS: MaybeUninit<InstructionAccount> =
+            MaybeUninit::<InstructionAccount>::uninit();
+        let mut instruction_accounts = [UNINIT_INSTRUCTION_ACCOUNTS; 2 + MAX_MULTISIG_SIGNERS];
+
+        // SAFETY:
+        // - `instruction_accounts` is sized to 2 + MAX_MULTISIG_SIGNERS
+        unsafe {
+            // - Index 0 is always present (TokenAccount)
+            instruction_accounts
+                .get_unchecked_mut(0)
+                .write(InstructionAccount::writable(token_account.address()));
+
+            // - Index 1 is always present (Authority)
+            instruction_accounts
+                .get_unchecked_mut(1)
+                .write(InstructionAccount::new(
+                    authority.address(),
+                    false,
+                    multisig_accounts.is_empty(),
+                ));
+        }
+
+        // add the multisig if they exist for each signer account
+        // creates a tuple of (account, signer) for each multisig i.e from index 2
+        for (instruction_account, signer) in instruction_accounts[2..]
+            .iter_mut()
+            .zip(multisig_accounts.iter())
+        {
+            instruction_account.write(InstructionAccount::readonly_signer(signer.address()));
+        }
+
+        // build instruction data for CpiGuard
+        let data = &[ExtensionDiscriminator::CpiGuard as u8, Self::DISCRIMINATOR];
+
+        let num_accounts = 2 + multisig_accounts.len();
+
+        // build instruction for CpiGuard
+        let instruction = InstructionView {
+            program_id: token_program,
+            data,
+            accounts: unsafe {
+                // create a slice &[] by providing the pointer to that data and the length of the data
+                slice::from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts)
+            },
+        };
+
+        // Account view array
+        const UNINIT_ACCOUNT_VIEWS: MaybeUninit<&AccountView> = MaybeUninit::uninit();
+        let mut account_views = [UNINIT_ACCOUNT_VIEWS; 2 + MAX_MULTISIG_SIGNERS];
+
+        // SAFETY:
+        // - `account_views` is sized to 2 + MAX_MULTISIG_SIGNERS
+        unsafe {
+            // - Index 0 is always present
+            account_views.get_unchecked_mut(0).write(token_account);
+            // - Index 1 is always present
+            account_views.get_unchecked_mut(1).write(authority);
+        }
+
+        // Fill signer accounts
+        for (account_view, signer) in account_views[2..].iter_mut().zip(multisig_accounts.iter()) {
+            account_view.write(signer);
+        }
+
+        invoke_signed_with_bounds::<{ 2 + MAX_MULTISIG_SIGNERS }>(
+            &instruction,
+            unsafe {
+                slice::from_raw_parts(account_views.as_ptr() as *const &AccountView, num_accounts)
+            },
+            signers,
+        )
+    }
+}

--- a/programs/token-2022/src/instructions/extensions/cpi_guard/disable.rs
+++ b/programs/token-2022/src/instructions/extensions/cpi_guard/disable.rs
@@ -23,7 +23,7 @@ use {
 /// 1. `[readonly]` The multisig account that owns the token account.
 /// 2. `[signer]` M signer accounts (as required by the multisig).
 pub struct DisableCpiGuard<'a, 'b, 'c> {
-    /// The token account to enable with the Memo-Transfer extension.
+    /// The token account to enable with the CpiGuard extension.
     pub token_account: &'a AccountView,
     /// The owner of the token account (single or multisig).
     pub authority: &'a AccountView,
@@ -59,33 +59,28 @@ impl DisableCpiGuard<'_, '_, '_> {
         // i.e. [token_account + authority](2) + signers(max_multisig_signers)
         const UNINIT_INSTRUCTION_ACCOUNTS: MaybeUninit<InstructionAccount> =
             MaybeUninit::<InstructionAccount>::uninit();
-        let mut instruction_accounts = [UNINIT_INSTRUCTION_ACCOUNTS; 2 + MAX_MULTISIG_SIGNERS];
+        let mut accounts = [UNINIT_INSTRUCTION_ACCOUNTS; 2 + MAX_MULTISIG_SIGNERS];
 
         // SAFETY:
-        // - `instruction_accounts` is sized to 2 + MAX_MULTISIG_SIGNERS
+        // - `accounts` is sized to 2 + MAX_MULTISIG_SIGNERS
+        // - Index 0 is always present (TokenAccount)
+        // - Index 1 is always present (Authority)
         unsafe {
-            // - Index 0 is always present (TokenAccount)
-            instruction_accounts
+            accounts
                 .get_unchecked_mut(0)
                 .write(InstructionAccount::writable(token_account.address()));
 
-            // - Index 1 is always present (Authority)
-            instruction_accounts
-                .get_unchecked_mut(1)
-                .write(InstructionAccount::new(
-                    authority.address(),
-                    false,
-                    multisig_accounts.is_empty(),
-                ));
+            accounts.get_unchecked_mut(1).write(InstructionAccount::new(
+                authority.address(),
+                false,
+                multisig_accounts.is_empty(),
+            ));
         }
 
         // add the multisig if they exist for each signer account
         // creates a tuple of (account, signer) for each multisig i.e from index 2
-        for (instruction_account, signer) in instruction_accounts[2..]
-            .iter_mut()
-            .zip(multisig_accounts.iter())
-        {
-            instruction_account.write(InstructionAccount::readonly_signer(signer.address()));
+        for (account, signer) in accounts[2..].iter_mut().zip(multisig_accounts.iter()) {
+            account.write(InstructionAccount::readonly_signer(signer.address()));
         }
 
         // build instruction data for CpiGuard
@@ -99,7 +94,7 @@ impl DisableCpiGuard<'_, '_, '_> {
             data,
             accounts: unsafe {
                 // create a slice &[] by providing the pointer to that data and the length of the data
-                slice::from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts)
+                slice::from_raw_parts(accounts.as_ptr() as _, num_accounts)
             },
         };
 
@@ -109,10 +104,10 @@ impl DisableCpiGuard<'_, '_, '_> {
 
         // SAFETY:
         // - `account_views` is sized to 2 + MAX_MULTISIG_SIGNERS
+        // - Index 0 is always present
+        // - Index 1 is always present
         unsafe {
-            // - Index 0 is always present
             account_views.get_unchecked_mut(0).write(token_account);
-            // - Index 1 is always present
             account_views.get_unchecked_mut(1).write(authority);
         }
 

--- a/programs/token-2022/src/instructions/extensions/cpi_guard/disable.rs
+++ b/programs/token-2022/src/instructions/extensions/cpi_guard/disable.rs
@@ -111,7 +111,7 @@ impl DisableCpiGuard<'_, '_, '_> {
             account_views.get_unchecked_mut(1).write(authority);
         }
 
-        // Fill signer accounts
+        // Fill all signer accounts
         for (account_view, signer) in account_views[2..].iter_mut().zip(multisig_accounts.iter()) {
             account_view.write(signer);
         }

--- a/programs/token-2022/src/instructions/extensions/cpi_guard/enable.rs
+++ b/programs/token-2022/src/instructions/extensions/cpi_guard/enable.rs
@@ -1,0 +1,132 @@
+use {
+    crate::{instructions::extensions::ExtensionDiscriminator, instructions::MAX_MULTISIG_SIGNERS},
+    core::{mem::MaybeUninit, slice},
+    solana_account_view::AccountView,
+    solana_address::Address,
+    solana_instruction_view::{
+        cpi::{invoke_signed_with_bounds, Signer},
+        InstructionAccount, InstructionView,
+    },
+    solana_program_error::{ProgramError, ProgramResult},
+};
+
+/// Enable the CPI Guard extension on a token account.
+///
+/// Expected accounts:
+///
+/// **Single authority**
+/// 0. `[writable]` The token account to enable cpi-guard.
+/// 1. `[signer]` The owner of the token account.
+///
+/// **Multisignature authority**
+/// 0. `[writable]` The token account to enable cpi-guard.
+/// 1. `[readonly]` The multisig account that owns the token account.
+/// 2. `[signer]` M signer accounts (as required by the multisig).
+pub struct EnableCpiGuard<'a, 'b, 'c> {
+    /// The token account to enable with the Memo-Transfer extension.
+    pub token_account: &'a AccountView,
+    /// The owner of the token account (single or multisig).
+    pub authority: &'a AccountView,
+    /// Signer accounts if the authority is a multisig.
+    pub signers: &'c [&'a AccountView],
+    /// Token program (Token-2022).
+    pub token_program: &'b Address,
+}
+
+impl EnableCpiGuard<'_, '_, '_> {
+    pub const DISCRIMINATOR: u8 = 0;
+
+    #[inline(always)]
+    pub fn invoke(&self) -> ProgramResult {
+        self.invoke_signed(&[])
+    }
+
+    #[inline(always)]
+    pub fn invoke_signed(&self, signers: &[Signer]) -> ProgramResult {
+        let &Self {
+            token_account,
+            authority,
+            signers: multisig_accounts,
+            token_program,
+            ..
+        } = self;
+
+        if multisig_accounts.len() > MAX_MULTISIG_SIGNERS {
+            return Err(ProgramError::InvalidArgument);
+        }
+
+        // creates an array of uninitialized InstructionAccount with 2 + MAX_MULTISIG_SIGNERS
+        // i.e. [token_account + authority](2) + signers(max_multisig_signers)
+        const UNINIT_INSTRUCTION_ACCOUNTS: MaybeUninit<InstructionAccount> =
+            MaybeUninit::<InstructionAccount>::uninit();
+        let mut instruction_accounts = [UNINIT_INSTRUCTION_ACCOUNTS; 2 + MAX_MULTISIG_SIGNERS];
+
+        // SAFETY:
+        // - `instruction_accounts` is sized to 2 + MAX_MULTISIG_SIGNERS
+        unsafe {
+            // - Index 0 is always present (TokenAccount)
+            instruction_accounts
+                .get_unchecked_mut(0)
+                .write(InstructionAccount::writable(token_account.address()));
+
+            // - Index 1 is always present (Authority)
+            instruction_accounts
+                .get_unchecked_mut(1)
+                .write(InstructionAccount::new(
+                    authority.address(),
+                    false,
+                    multisig_accounts.is_empty(),
+                ));
+        }
+
+        // add the multisig if they exist for each signer account
+        // creates a tuple of (account, signer) for each multisig i.e from index 2
+        for (instruction_account, signer) in instruction_accounts[2..]
+            .iter_mut()
+            .zip(multisig_accounts.iter())
+        {
+            instruction_account.write(InstructionAccount::readonly_signer(signer.address()));
+        }
+
+        // build instruction data for CpiGuard
+        let data = &[ExtensionDiscriminator::CpiGuard as u8, Self::DISCRIMINATOR];
+
+        let num_accounts = 2 + multisig_accounts.len();
+
+        // build instruction for CpiGuard
+        let instruction = InstructionView {
+            program_id: token_program,
+            data,
+            accounts: unsafe {
+                // create a slice &[] by providing the pointer to that data and the length of the data
+                slice::from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts)
+            },
+        };
+
+        // Account view array
+        const UNINIT_ACCOUNT_VIEWS: MaybeUninit<&AccountView> = MaybeUninit::uninit();
+        let mut account_views = [UNINIT_ACCOUNT_VIEWS; 2 + MAX_MULTISIG_SIGNERS];
+
+        // SAFETY:
+        // - `account_views` is sized to 2 + MAX_MULTISIG_SIGNERS
+        unsafe {
+            // - Index 0 is always present
+            account_views.get_unchecked_mut(0).write(token_account);
+            // - Index 1 is always present
+            account_views.get_unchecked_mut(1).write(authority);
+        }
+
+        // Fill signer accounts
+        for (account_view, signer) in account_views[2..].iter_mut().zip(multisig_accounts.iter()) {
+            account_view.write(signer);
+        }
+
+        invoke_signed_with_bounds::<{ 2 + MAX_MULTISIG_SIGNERS }>(
+            &instruction,
+            unsafe {
+                slice::from_raw_parts(account_views.as_ptr() as *const &AccountView, num_accounts)
+            },
+            signers,
+        )
+    }
+}

--- a/programs/token-2022/src/instructions/extensions/cpi_guard/enable.rs
+++ b/programs/token-2022/src/instructions/extensions/cpi_guard/enable.rs
@@ -111,7 +111,7 @@ impl EnableCpiGuard<'_, '_, '_> {
             account_views.get_unchecked_mut(1).write(authority);
         }
 
-        // Fill signer accounts
+        // Fill all signer accounts
         for (account_view, signer) in account_views[2..].iter_mut().zip(multisig_accounts.iter()) {
             account_view.write(signer);
         }

--- a/programs/token-2022/src/instructions/extensions/cpi_guard/enable.rs
+++ b/programs/token-2022/src/instructions/extensions/cpi_guard/enable.rs
@@ -23,7 +23,7 @@ use {
 /// 1. `[readonly]` The multisig account that owns the token account.
 /// 2. `[signer]` M signer accounts (as required by the multisig).
 pub struct EnableCpiGuard<'a, 'b, 'c> {
-    /// The token account to enable with the Memo-Transfer extension.
+    /// The token account to enable with the CpiGuard extension.
     pub token_account: &'a AccountView,
     /// The owner of the token account (single or multisig).
     pub authority: &'a AccountView,
@@ -59,33 +59,28 @@ impl EnableCpiGuard<'_, '_, '_> {
         // i.e. [token_account + authority](2) + signers(max_multisig_signers)
         const UNINIT_INSTRUCTION_ACCOUNTS: MaybeUninit<InstructionAccount> =
             MaybeUninit::<InstructionAccount>::uninit();
-        let mut instruction_accounts = [UNINIT_INSTRUCTION_ACCOUNTS; 2 + MAX_MULTISIG_SIGNERS];
+        let mut accounts = [UNINIT_INSTRUCTION_ACCOUNTS; 2 + MAX_MULTISIG_SIGNERS];
 
         // SAFETY:
-        // - `instruction_accounts` is sized to 2 + MAX_MULTISIG_SIGNERS
+        // - `accounts` is sized to 2 + MAX_MULTISIG_SIGNERS
+        // - Index 0 is always present (TokenAccount)
+        // - Index 1 is always present (Authority)
         unsafe {
-            // - Index 0 is always present (TokenAccount)
-            instruction_accounts
+            accounts
                 .get_unchecked_mut(0)
                 .write(InstructionAccount::writable(token_account.address()));
 
-            // - Index 1 is always present (Authority)
-            instruction_accounts
-                .get_unchecked_mut(1)
-                .write(InstructionAccount::new(
-                    authority.address(),
-                    false,
-                    multisig_accounts.is_empty(),
-                ));
+            accounts.get_unchecked_mut(1).write(InstructionAccount::new(
+                authority.address(),
+                false,
+                multisig_accounts.is_empty(),
+            ));
         }
 
         // add the multisig if they exist for each signer account
         // creates a tuple of (account, signer) for each multisig i.e from index 2
-        for (instruction_account, signer) in instruction_accounts[2..]
-            .iter_mut()
-            .zip(multisig_accounts.iter())
-        {
-            instruction_account.write(InstructionAccount::readonly_signer(signer.address()));
+        for (account, signer) in accounts[2..].iter_mut().zip(multisig_accounts.iter()) {
+            account.write(InstructionAccount::readonly_signer(signer.address()));
         }
 
         // build instruction data for CpiGuard
@@ -99,7 +94,7 @@ impl EnableCpiGuard<'_, '_, '_> {
             data,
             accounts: unsafe {
                 // create a slice &[] by providing the pointer to that data and the length of the data
-                slice::from_raw_parts(instruction_accounts.as_ptr() as _, num_accounts)
+                slice::from_raw_parts(accounts.as_ptr() as _, num_accounts)
             },
         };
 
@@ -109,10 +104,10 @@ impl EnableCpiGuard<'_, '_, '_> {
 
         // SAFETY:
         // - `account_views` is sized to 2 + MAX_MULTISIG_SIGNERS
+        // - Index 0 is always present
+        // - Index 1 is always present
         unsafe {
-            // - Index 0 is always present
             account_views.get_unchecked_mut(0).write(token_account);
-            // - Index 1 is always present
             account_views.get_unchecked_mut(1).write(authority);
         }
 

--- a/programs/token-2022/src/instructions/extensions/cpi_guard/mod.rs
+++ b/programs/token-2022/src/instructions/extensions/cpi_guard/mod.rs
@@ -1,0 +1,5 @@
+pub mod disable;
+pub mod enable;
+
+pub use disable::*;
+pub use enable::*;

--- a/programs/token-2022/src/instructions/extensions/mod.rs
+++ b/programs/token-2022/src/instructions/extensions/mod.rs
@@ -1,7 +1,9 @@
+pub mod cpi_guard;
 pub mod memo_transfer;
 
 #[repr(u8)]
 #[non_exhaustive]
 pub enum ExtensionDiscriminator {
     MemoTransfer = 30,
+    CpiGuard = 34,
 }


### PR DESCRIPTION
Added the `EnableCpiGuard` and `DisableCpiGuard` instructions in cpi-guard extension

```rust
pub struct EnableCpiGuard<'a, 'b, 'c> {
    /// The token account to enable with the Memo-Transfer extension.
    pub token_account: &'a AccountView,
    /// The owner of the token account (single or multisig).
    pub authority: &'a AccountView,
    /// Signer accounts if the authority is a multisig.
    pub signers: &'c [&'a AccountView],
    /// Token program (Token-2022).
    pub token_program: &'b Address,
}
```