### PR TITLE
token-2022: Nits for permanent delegate instruction

### DIFF
--- a/programs/token-2022/src/instructions/extensions/permanent_delegate/mod.rs
+++ b/programs/token-2022/src/instructions/extensions/permanent_delegate/mod.rs
@@ -1,2 +1,3 @@
-pub mod initialize;
+mod initialize;
+
 pub use initialize::*;


### PR DESCRIPTION
Nits (mainly formatting) for the permanent delegate extension.